### PR TITLE
chore(gha): cleanup release jobs to not run build twice

### DIFF
--- a/.github/workflows/tag_release.yaml
+++ b/.github/workflows/tag_release.yaml
@@ -6,21 +6,6 @@ on:
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 jobs:
-  operator-build:
-    runs-on: ubuntu-latest
-    name: Build
-    steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-    - name: Install Go
-      uses: actions/setup-go@v2.1.1
-      with:
-        go-version: '1.14.6'
-    - name: GoReleaser
-      uses: goreleaser/goreleaser-action@v2
-      with:
-        version: latest
-        args: release --snapshot --skip-publish --rm-dist --skip-sign
   operator-int-tests:
     runs-on: ubuntu-latest
     name: Integration Testing
@@ -70,7 +55,7 @@ jobs:
       run: |
         scripts/ci-cluster-destroy.sh
   release:
-    needs: [operator-build, operator-int-tests]
+    needs: [operator-int-tests]
     runs-on: ubuntu-latest
     name: Tag Release
     steps:


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

chore(gha): cleanup release jobs to not run build twice

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
