### PR TITLE
fix(stack-cntlr): add SSH keyagent, add keys to known_hosts for SSH git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
-# FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 FROM pulumi/pulumi:v2.10.0
 
 ENV OPERATOR=/usr/local/bin/pulumi-kubernetes-operator
-#    USER_UID=1001 \
-#    USER_NAME=pulumi-kubernetes-operator
 
 # install operator binary
 COPY pulumi-kubernetes-operator ${OPERATOR}
@@ -12,6 +9,11 @@ COPY build/bin/* /usr/local/bin/
 RUN  /usr/local/bin/user_setup
 
 RUN useradd -m pulumi-kubernetes-operator
+RUN mkdir -p /home/pulumi-kubernetes-operator/.ssh \
+    && touch /home/pulumi-kubernetes-operator/.ssh/known_hosts \
+    && chmod 700 /home/pulumi-kubernetes-operator/.ssh \
+    && chown -R pulumi-kubernetes-operator:pulumi-kubernetes-operator /home/pulumi-kubernetes-operator/.ssh
+
 USER pulumi-kubernetes-operator
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ const operatorDeployment = new kubernetes.apps.v1.Deployment("operatorDeployment
                 containers: [{
                     name: "pulumi-kubernetes-operator",
                     image: "pulumi/pulumi-kubernetes-operator:v0.0.5",
-                    command: ["pulumi-kubernetes-operator"],
                     args: ["--zap-level=debug"],
                     imagePullPolicy: "Always",
                     env: [

--- a/build/bin/entrypoint
+++ b/build/bin/entrypoint
@@ -1,3 +1,4 @@
 #!/bin/sh -e
 
-exec ${OPERATOR} $@
+eval "$(ssh-agent -s)"
+exec env SSH_AUTH_SOCK="$SSH_AUTH_SOCK" SSH_AGENT_PID="$SSH_AGENT_PID" "${OPERATOR}" "$@"

--- a/deploy/operator_template.yaml
+++ b/deploy/operator_template.yaml
@@ -19,8 +19,6 @@ spec:
       containers:
         - name: pulumi-kubernetes-operator
           image: <IMG_NAME>:<IMG_VERSION>
-          command:
-          - pulumi-kubernetes-operator
           args:
           - "--zap-level=debug"
           imagePullPolicy: Always

--- a/deploy/yaml/operator.yaml
+++ b/deploy/yaml/operator.yaml
@@ -19,8 +19,6 @@ spec:
       containers:
         - name: pulumi-kubernetes-operator
           image: pulumi/pulumi-kubernetes-operator:v0.0.5
-          command:
-          - pulumi-kubernetes-operator
           args:
           - "--zap-level=debug"
           imagePullPolicy: Always

--- a/examples/blue-green/operator.ts
+++ b/examples/blue-green/operator.ts
@@ -192,7 +192,6 @@ export class PulumiKubernetesOperator extends pulumi.ComponentResource {
                         containers: [{
                             name: "pulumi-kubernetes-operator",
                             image: "pulumi/pulumi-kubernetes-operator:v0.0.5",
-                            command: ["pulumi-kubernetes-operator"],
                             args: ["--zap-level=debug"],
                             imagePullPolicy: "Always",
                             env: [

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/pulumi/sdk/v2 v2.10.1-0.20200915174902-4e6ea760db2e
 	github.com/spf13/pflag v1.0.5
+	github.com/whilp/git-urls v1.0.0
 	golang.org/x/mod v0.3.0 // indirect
 	golang.org/x/tools v0.0.0-20200617161249-6222995d070a // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1

--- a/go.sum
+++ b/go.sum
@@ -892,6 +892,8 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
+github.com/whilp/git-urls v1.0.0 h1:95f6UMWN5FKW71ECsXRUd3FVYiXdrE7aX4NZKcPmIjU=
+github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgwk/qCfE=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=

--- a/stack-examples/yaml/s3_bucket_stack_basic_auth.yaml
+++ b/stack-examples/yaml/s3_bucket_stack_basic_auth.yaml
@@ -34,7 +34,7 @@ spec:
     - pulumi-aws-secrets
   gitAuthSecret: git-secret
   stack: joeduffy/s3-op-project/dev
-  projectRepo: git@github.com:joeduffy/test-s3-op-project.git
+  projectRepo: https://github.com/joeduffy/test-s3-op-project
   commit: cc5442870f1195216d6bc340c14f8ae7d28cf3e2
   config:
     aws:region: us-east-2

--- a/stack-examples/yaml/s3_bucket_stack_ssh.yaml
+++ b/stack-examples/yaml/s3_bucket_stack_ssh.yaml
@@ -12,8 +12,9 @@ metadata:
   name: git-secret
 type: Opaque
 data:
+  # need to base64 SSH private key to set a valid YAML value
   sshPrivateKey: "<REDACTED: BASE64_ENCODED_SSH_PRIVATE_KEY>"
-  password: "<REDACTED: OPTIONAL_SSH_KEY_PASSWORD>"
+  password: "<REDACTED: OPTIONAL_BASE64_ENCODED_SSH_KEY_PASSWORD>"
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

- Enable a SSH keyagent needed for go-git to use the SSH transport during git clones.
- Add the public SSH keys for the project repo URL host to ~/.ssh/known_hosts
  to enforce strict key checking during git clones.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

Closes #91