### PR TITLE
Add `backend` configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pulumi/pulumi:v2.10.0
+FROM pulumi/pulumi:v2.15.0
 
 ENV OPERATOR=/usr/local/bin/pulumi-kubernetes-operator
 

--- a/deploy/crds/pulumi.com_stacks.yaml
+++ b/deploy/crds/pulumi.com_stacks.yaml
@@ -33,7 +33,10 @@ spec:
           description: StackSpec defines the desired state of Pulumi Stack being managed by this operator.
           properties:
             accessTokenSecret:
-              description: AccessTokenSecret is the name of a secret containing the PULUMI_ACCESS_TOKEN for Pulumi access.
+              description: (optional) AccessTokenSecret is the name of a secret containing the PULUMI_ACCESS_TOKEN for Pulumi access.
+              type: string
+            backend:
+              description: (optional) Backend is an optional backend URL to use for all Pulumi operations.
               type: string
             branch:
               description: (optional) Branch is the branch name to deploy, either the simple or fully qualified ref name. This is mutually exclusive with the Commit setting. If both are empty, the `master` branch is deployed.
@@ -89,7 +92,6 @@ spec:
               description: Stack is the fully qualified name of the stack to deploy (<org>/<stack>).
               type: string
           required:
-          - accessTokenSecret
           - projectRepo
           - stack
           type: object

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/operator-framework/operator-lib v0.0.0-20200728190837-b76db547798d
 	github.com/operator-framework/operator-sdk v0.19.0
 	github.com/pkg/errors v0.9.1
-	github.com/pulumi/pulumi/sdk/v2 v2.12.1
+	github.com/pulumi/pulumi/sdk/v2 v2.15.0
 	github.com/spf13/pflag v1.0.5
 	github.com/whilp/git-urls v1.0.0
 	golang.org/x/mod v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -355,6 +355,8 @@ github.com/gocql/gocql v0.0.0-20190301043612-f6df8288f9b4/go.mod h1:4Fw1eo5iaEhD
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/gofrs/flock v0.7.1 h1:DP+LD/t0njgoPBvT5MJLeliUIVQR03hiKR6vezdwHlc=
 github.com/gofrs/flock v0.7.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
+github.com/gofrs/uuid v3.3.0+incompatible h1:8K4tyRfvU1CYPgJsveYFQMhpFd/wXNM7iK6rR7UHz84=
+github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -789,6 +791,8 @@ github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/pulumi/sdk/v2 v2.12.1 h1:rEQHyjaGSGybqqeKLMJZH034UemMPGw2AWzpGcn1tF4=
 github.com/pulumi/pulumi/sdk/v2 v2.12.1/go.mod h1:WQ4WaHMA7mduVHAJi87iIqbWvqsuBUYccBiKK+FrayI=
+github.com/pulumi/pulumi/sdk/v2 v2.15.0 h1:gTiohXl5dyw3z/aKbuhrN50KQMYFFKnGwebPWvOIvs8=
+github.com/pulumi/pulumi/sdk/v2 v2.15.0/go.mod h1:Z9ifPo/Q0+hUpAyguVx2gp5Sx+CBumnWvYQDhrM8l3E=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/robfig/cron v0.0.0-20170526150127-736158dc09e1/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=

--- a/pkg/apis/pulumi/v1alpha1/stack_types.go
+++ b/pkg/apis/pulumi/v1alpha1/stack_types.go
@@ -12,12 +12,15 @@ import (
 type StackSpec struct {
 	// Auth info:
 
-	// AccessTokenSecret is the name of a secret containing the PULUMI_ACCESS_TOKEN for Pulumi access.
-	AccessTokenSecret string `json:"accessTokenSecret"`
+	// (optional) AccessTokenSecret is the name of a secret containing the PULUMI_ACCESS_TOKEN for Pulumi access.
+	AccessTokenSecret string `json:"accessTokenSecret,omitempty"`
 	// (optional) Envs is an optional array of config maps containing environment variables to set.
 	Envs []string `json:"envs,omitempty"`
 	// (optional) SecretEnvs is an optional array of secret names containing environment variables to set.
 	SecretEnvs []string `json:"envSecrets,omitempty"`
+
+	// (optional) Backend is an optional backend URL to use for all Pulumi operations.
+	Backend string `json:"backend,omitempty"`
 
 	// Stack identity:
 

--- a/pkg/apis/pulumi/v1alpha1/stack_types.go
+++ b/pkg/apis/pulumi/v1alpha1/stack_types.go
@@ -18,8 +18,15 @@ type StackSpec struct {
 	Envs []string `json:"envs,omitempty"`
 	// (optional) SecretEnvs is an optional array of secret names containing environment variables to set.
 	SecretEnvs []string `json:"envSecrets,omitempty"`
-
 	// (optional) Backend is an optional backend URL to use for all Pulumi operations.
+	// Examples:
+	//   - Pulumi Service:              "https://app.pulumi.com" (default)
+	//   - Self-managed Pulumi Service: "https://pulumi.acmecorp.com"
+	//   - Local:                       "file://./einstein"
+	//   - AWS:                         "s3://<my-pulumi-state-bucket>"
+	//   - Azure:                       "azblob://<my-pulumi-state-bucket>"
+	//   - GCP:                         "gs://<my-pulumi-state-bucket>"
+	// See: https://www.pulumi.com/docs/intro/concepts/state/
 	Backend string `json:"backend,omitempty"`
 
 	// Stack identity:

--- a/test/stack_controller_test.go
+++ b/test/stack_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base32"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -120,9 +121,16 @@ var _ = Describe("Stack Controller", func() {
 		stackName := fmt.Sprintf("%s/s3-op-project/dev-%s", stackOrg, randString())
 		fmt.Fprintf(GinkgoWriter, "Stack.Name: %s\n", stackName)
 
+		// Use a local backend for this test
+		backendDir, err := ioutil.TempDir("", "")
+		if err != nil {
+			Fail("Could not create backend directory")
+		}
+		defer os.RemoveAll(backendDir)
+
 		// Define the stack spec
 		spec := pulumiv1alpha1.StackSpec{
-			AccessTokenSecret: pulumiAPISecret.ObjectMeta.Name,
+			Backend: fmt.Sprintf("file://%s", backendDir),
 			SecretEnvs: []string{
 				pulumiAWSSecret.ObjectMeta.Name,
 			},


### PR DESCRIPTION
Adds a top level `backend` field to the Stack CR that allows pointing all operations for the target Stack at the given backend.  In cases where `backend` is set to a non-service backend, the AccessTokenSecret field is also no longer required.

This is dependent on https://github.com/pulumi/pulumi/pull/5789, and cannot be merged until the operator can take a dependency on that change in the core `pulumi` CLI.

Fixes #83.
