### PR TITLE
Fix stack state message regression

### DIFF
--- a/deploy/crds/pulumi.com_stacks.yaml
+++ b/deploy/crds/pulumi.com_stacks.yaml
@@ -101,6 +101,12 @@ spec:
             lastUpdate:
               description: LastUpdate contains details of the status of the last update.
               properties:
+                lastAttemptedCommit:
+                  description: Last commit attempted
+                  type: string
+                lastSuccessfulCommit:
+                  description: Last commit successfully applied
+                  type: string
                 permalink:
                   description: Permalink is the Pulumi Console URL of the stack operation.
                   type: string

--- a/go.sum
+++ b/go.sum
@@ -789,8 +789,6 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi/sdk/v2 v2.12.1 h1:rEQHyjaGSGybqqeKLMJZH034UemMPGw2AWzpGcn1tF4=
-github.com/pulumi/pulumi/sdk/v2 v2.12.1/go.mod h1:WQ4WaHMA7mduVHAJi87iIqbWvqsuBUYccBiKK+FrayI=
 github.com/pulumi/pulumi/sdk/v2 v2.15.0 h1:gTiohXl5dyw3z/aKbuhrN50KQMYFFKnGwebPWvOIvs8=
 github.com/pulumi/pulumi/sdk/v2 v2.15.0/go.mod h1:Z9ifPo/Q0+hUpAyguVx2gp5Sx+CBumnWvYQDhrM8l3E=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/pkg/apis/pulumi/v1alpha1/stack_types.go
+++ b/pkg/apis/pulumi/v1alpha1/stack_types.go
@@ -107,7 +107,11 @@ type StackOutputs map[string]apiextensionsv1.JSON
 // StackUpdateState is the status of a stack update
 type StackUpdateState struct {
 	// State is the state of the stack update - one of `succeeded` or `failed`
-	State string `json:"state,omitempty"`
+	State StackUpdateStateMessage `json:"state,omitempty"`
+	// Last commit attempted
+	LastAttemptedCommit string `json:"lastAttemptedCommit,omitempty"`
+	// Last commit successfully applied
+	LastSuccessfulCommit string `json:"lastSuccessfulCommit,omitempty"`
 	// Permalink is the Pulumi Console URL of the stack operation.
 	Permalink Permalink `json:"permalink,omitempty"`
 }
@@ -153,8 +157,14 @@ const (
 	StackNotFound StackUpdateStatus = 4
 )
 
-// FailedStackStateMessage is a const to indicate stack failure in the status.
-const FailedStackStateMessage = "failed"
+type StackUpdateStateMessage string
+
+const (
+	// SucceededStackStateMessage is a const to indicate success in stack status state.
+	SucceededStackStateMessage StackUpdateStateMessage = "succeeded"
+	// FailedStackStateMessage is a const to indicate stack failure in stack status state.
+	FailedStackStateMessage StackUpdateStateMessage = "failed"
+)
 
 // Permalink is the Pulumi Service URL of the stack operation.
 type Permalink string

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -173,6 +173,15 @@ func (r *ReconcileStack) Reconcile(request reconcile.Request) (reconcile.Result,
 		return reconcile.Result{}, err
 	}
 
+	// Delete the working directory after the reconciliation is completed (regardless of success or failure).
+	defer func() {
+		if sess.workdir != "" {
+			if err := os.RemoveAll(sess.workdir); err != nil {
+				sess.logger.Error(err, "Failed to delete working dir: %s", sess.workdir)
+			}
+		}
+	}()
+
 	// Step 2. If there are extra environment variables, read them in now and use them for subsequent commands.
 	err = sess.SetEnvs(stack.Envs, request.Namespace)
 	if err != nil {

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -253,11 +253,10 @@ func (r *ReconcileStack) Reconcile(request reconcile.Request) (reconcile.Result,
 		if err != nil {
 			reqLogger.Error(err, "Failed to update Stack", "Stack.Name", stack.Stack)
 			// Update Stack status with failed state
-			instance.Status.LastUpdate = &pulumiv1alpha1.StackUpdateState{
-				LastAttemptedCommit: instance.Spec.Commit,
-				State:               pulumiv1alpha1.FailedStackStateMessage,
-				Permalink:           permalink,
-			}
+			instance.Status.LastUpdate.LastAttemptedCommit = instance.Spec.Commit
+			instance.Status.LastUpdate.State = pulumiv1alpha1.FailedStackStateMessage
+			instance.Status.LastUpdate.Permalink = permalink
+
 			if err2 := sess.updateResourceStatus(instance); err2 != nil {
 				msg := "Failed to update status for a failed Stack update"
 				err3 := errors.Wrapf(err, err2.Error())

--- a/test/stack_controller_test.go
+++ b/test/stack_controller_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Stack Controller", func() {
 				return false
 			}
 			if fetched.Status.LastUpdate != nil {
-				return fetched.Status.LastUpdate.State == stack.Spec.Commit
+				return fetched.Status.LastUpdate.LastSuccessfulCommit == stack.Spec.Commit
 			}
 			return false
 		}, timeout, interval).Should(BeTrue())
@@ -207,7 +207,7 @@ var _ = Describe("Stack Controller", func() {
 				return false
 			}
 			if original.Status.LastUpdate != nil {
-				return original.Status.LastUpdate.State == stack.Spec.Commit
+				return original.Status.LastUpdate.LastSuccessfulCommit == stack.Spec.Commit
 			}
 			return false
 		}, timeout, interval).Should(BeTrue())
@@ -224,7 +224,7 @@ var _ = Describe("Stack Controller", func() {
 				return false
 			}
 			if fetched.Status.LastUpdate != nil {
-				return fetched.Status.LastUpdate.State == commit
+				return fetched.Status.LastUpdate.LastSuccessfulCommit == commit
 			}
 			return false
 		}, timeout, interval).Should(BeTrue())


### PR DESCRIPTION
Fixes #102 and #98  which was caused due to what appears to be a regression in functionality introduced in #29.

We now record the last attempted and successful commits explicitly in their own fields in the `StackUpdateState` subresource under stack.
The original intent of reusing `StackUpdateState.State` for success and commit recording isn't clear. I have run the integration test suite locally multiple times with success which allays my fears about introducing this change given that #29 was merged to address issues demonstrated by the test suite.

In addition, we were never deleting the working directories and creating a new workspace for each reconciliation loop which resulted in #104. I considered retaining the workspace for the lifetime of the stack which might help avoid pulling down dependencies etc. multiple times. However, recreating the workspace every time seems to be more desirable than tying the lifecycle of the workspace/working directory to the stack (for determinism/reproducibility). As a result, we now delete the workspace working directory after each reconciliation - see https://github.com/pulumi/pulumi-kubernetes-operator/pull/107/commits/8bc27237f89731ab7dddc22a03918b4980438a0f. While the most desirable fix for this will come through #78, this should have a significant impact in the meantime.

**Note** that CI integration is currently failing in this repo due to recent deprecations of certain GHA commands. Working to fix those separately. 

