### PR TITLE
Use ephemeral storage for disk mutations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,7 @@ RUN mkdir -p /home/pulumi-kubernetes-operator/.ssh \
 
 USER pulumi-kubernetes-operator
 
+ENV XDG_CONFIG_HOME=/tmp/.config
+ENV XDG_CONFIG_CACHE=/tmp/.cache
+
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/deploy/operator_template.yaml
+++ b/deploy/operator_template.yaml
@@ -16,12 +16,18 @@ spec:
       serviceAccountName: pulumi-kubernetes-operator
       imagePullSecrets:
         - name: pulumi-kubernetes-operator
+      volumes:
+        - name: tmp-dir
+          emptyDir: {}
       containers:
         - name: pulumi-kubernetes-operator
           image: <IMG_NAME>:<IMG_VERSION>
           args:
-          - "--zap-level=debug"
+            - "--zap-level=debug"
           imagePullPolicy: Always
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-dir
           env:
             - name: WATCH_NAMESPACE
               valueFrom:


### PR DESCRIPTION
Fixes #96. Prerequisite for #78 and should help with #104 as well.

Two changes here:
1. Set the global config and cache directories to be in /tmp. The Docker image by default seemed to be using `/root/.xyz` which is the reason for #96.
2. We should be avoiding writing state back into the image (overlay). `/tmp` is now an emptyDir mount which will make the entire /tmp directory ephimeral for the lifecycle of the pod. Once the pod dies, the storage is immediately released. This would be valuable for #78 