### PR TITLE
Fix repoDir handling and update tests accordingly

### DIFF
--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -638,7 +638,7 @@ func (sess *reconcileStackSession) CleanupPulumiWorkdir() {
 
 // Determine the actual commit information from the working directory (Spec commit etc. is optional).
 func revisionAtWorkingDir(workingDir string) (string, error) {
-	gitRepo, err := git.PlainOpen(workingDir)
+	gitRepo, err := git.PlainOpenWithOptions(workingDir, &git.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to resolve git repository from working directory: %s", workingDir)
 	}

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -475,7 +475,7 @@ func (sess *reconcileStackSession) resolveResourceRef(ref *pulumiv1alpha1.Resour
 func (sess *reconcileStackSession) runCmd(title string, cmd *exec.Cmd, workspace auto.Workspace) (string, string, error) {
 	// If not overridden, set the command to run in the working directory.
 	if cmd.Dir == "" {
-		cmd.Dir = workspace.WorkDir()
+		cmd.Dir = sess.workdir
 	}
 
 	// Init environment variables.
@@ -580,6 +580,10 @@ func (sess *reconcileStackSession) SetupPulumiWorkdir(gitAuth *auto.GitAuth) err
 		return err
 	}
 	sess.workdir = w.WorkDir()
+
+	if repo.ProjectPath != "" {
+		sess.workdir = filepath.Join(sess.workdir, repo.ProjectPath)
+	}
 
 	// Create a new stack if the stack does not already exist, or fall back to
 	// selecting the existing stack. If the stack does not exist, it will be created and selected.

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -581,10 +581,6 @@ func (sess *reconcileStackSession) SetupPulumiWorkdir(gitAuth *auto.GitAuth) err
 	}
 	sess.workdir = w.WorkDir()
 
-	if repo.ProjectPath != "" {
-		sess.workdir = filepath.Join(sess.workdir, repo.ProjectPath)
-	}
-
 	// Create a new stack if the stack does not already exist, or fall back to
 	// selecting the existing stack. If the stack does not exist, it will be created and selected.
 	a, err := auto.UpsertStack(context.Background(), sess.stack.Stack, w)

--- a/test/stack_controller_test.go
+++ b/test/stack_controller_test.go
@@ -243,7 +243,7 @@ var _ = Describe("Stack Controller", func() {
 			},
 			Stack:             stackName,
 			ProjectRepo:       "https://github.com/pulumi/pulumi-kubernetes-operator",
-			RepoDir:           "test/testdata/s3-op-project",
+			RepoDir:           "test/testdata/test-s3-op-project",
 			Commit:            commit,
 			DestroyOnFinalize: true,
 		}
@@ -370,7 +370,7 @@ var _ = Describe("Stack Controller", func() {
 			},
 			Stack:             stackName,
 			ProjectRepo:       "https://github.com/pulumi/pulumi-kubernetes-operator",
-			RepoDir:           "test/testdata/s3-op-project",
+			RepoDir:           "test/testdata/test-s3-op-project",
 			Commit:            commit,
 			DestroyOnFinalize: true,
 		}

--- a/test/stack_controller_test.go
+++ b/test/stack_controller_test.go
@@ -179,9 +179,10 @@ var _ = Describe("Stack Controller", func() {
 		localSpec := pulumiv1alpha1.StackSpec{
 			Backend:         fmt.Sprintf("file://%s", backendDir),
 			Stack:           stackName,
-			ProjectRepo:     "https://github.com/viveklak/empty-stack", // TODO: relocate to some other repo
+			ProjectRepo:     "https://github.com/pulumi/pulumi-kubernetes-operator",
+			RepoDir:         "test/testdata/empty-stack",
 			SecretsProvider: "passphrase",
-			Commit:          "c011ac585dcf51b8c2793b9a684475dbd9a56bf3",
+			// Commit:          "", TODO
 			SecretEnvs: []string{
 				passphraseSecret.ObjectMeta.Name,
 			},
@@ -234,9 +235,10 @@ var _ = Describe("Stack Controller", func() {
 			Config: map[string]string{
 				"aws:region": "us-east-2",
 			},
-			Stack:             stackName,
-			ProjectRepo:       "https://github.com/metral/test-s3-op-project", // TODO: relocate to some other repo
-			Commit:            "bd1edfac28577d62068b7ace0586df595bda33be",
+			Stack:       stackName,
+			ProjectRepo: "https://github.com/pulumi/pulumi-kubernetes-operator",
+			RepoDir:     "test/testdata/s3-op-project",
+			// Commit:            "", TODO
 			DestroyOnFinalize: true,
 		}
 
@@ -360,9 +362,10 @@ var _ = Describe("Stack Controller", func() {
 			Config: map[string]string{
 				"aws:region": "us-east-2",
 			},
-			Stack:             stackName,
-			ProjectRepo:       "https://github.com/metral/test-s3-op-project", // TODO: relocate to some other repo
-			Commit:            "bd1edfac28577d62068b7ace0586df595bda33be",
+			Stack:       stackName,
+			ProjectRepo: "https://github.com/pulumi/pulumi-kubernetes-operator",
+			RepoDir:     "test/testdata/s3-op-project",
+			// Commit:            "", // TODO
 			DestroyOnFinalize: true,
 		}
 

--- a/test/stack_controller_test.go
+++ b/test/stack_controller_test.go
@@ -224,7 +224,7 @@ var _ = Describe("Stack Controller", func() {
 		var stack *pulumiv1alpha1.Stack
 		stackName := fmt.Sprintf("%s/s3-op-project/dev-commit-change-%s", stackOrg, randString())
 		fmt.Fprintf(GinkgoWriter, "Stack.Name: %s\n", stackName)
-		commit := "cc5442870f1195216d6bc340c14f8ae7d28cf3e2"
+		const commit = "cc5442870f1195216d6bc340c14f8ae7d28cf3e2"
 
 		// Define the stack spec
 		spec := pulumiv1alpha1.StackSpec{


### PR DESCRIPTION
Follow up to https://github.com/pulumi/pulumi-kubernetes-operator/pull/150.

Fixes #145 and converts existing tests to use repoDir to demonstrate fix.

