### PR TITLE
Update tests to track local commits only

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -38,6 +38,8 @@ jobs:
           # The following are to allow tests to run against local commits.
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+      # go-git doesn't like detached state.
+      - run: git switch -C "pull-request"
       - name: Install Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          # The following are to allow tests to run against local commits.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -34,6 +34,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          # The following are to allow tests to run against local commits.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          # The following are to allow tests to run against local commits.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,8 @@ jobs:
           # The following are to allow tests to run against local commits.
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+      # go-git doesn't like detached state.
+      - run: git switch -C "pull-request"
       - name: Install Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/run-acceptance-tests.yaml
+++ b/.github/workflows/run-acceptance-tests.yaml
@@ -30,10 +30,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-        with:
-          # The following are to allow tests to run against local commits.
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v2
         with:
@@ -50,6 +46,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          # The following are to allow tests to run against local commits.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/run-acceptance-tests.yaml
+++ b/.github/workflows/run-acceptance-tests.yaml
@@ -50,6 +50,8 @@ jobs:
           # The following are to allow tests to run against local commits.
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+      # go-git doesn't like detached state.
+      - run: git switch -C "pull-request"
       - name: Install Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/run-acceptance-tests.yaml
+++ b/.github/workflows/run-acceptance-tests.yaml
@@ -30,6 +30,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          # The following are to allow tests to run against local commits.
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v2
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,10 +49,6 @@ dockers:
     # GOARCH of the built binary that should be used.
     goarch: amd64
 
-    # Name templates of the built binaries that should be used.
-    binaries:
-    - "{{ .ProjectName }}"
-
     # Path to the Dockerfile (from the project root).
     dockerfile: Dockerfile
 

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -509,7 +509,7 @@ func (sess *reconcileStackSession) resolveResourceRef(ref *pulumiv1alpha1.Resour
 func (sess *reconcileStackSession) runCmd(title string, cmd *exec.Cmd, workspace auto.Workspace) (string, string, error) {
 	// If not overridden, set the command to run in the working directory.
 	if cmd.Dir == "" {
-		cmd.Dir = sess.workdir
+		cmd.Dir = workspace.WorkDir()
 	}
 
 	// Init environment variables.

--- a/test/stack_controller_test.go
+++ b/test/stack_controller_test.go
@@ -47,19 +47,22 @@ var _ = Describe("Stack Controller", func() {
 		Fail(fmt.Sprintf("Must get pulumi authorized user: %v", err))
 	}
 	stackOrg := strings.TrimSuffix(string(whoami), "\n")
-	fmt.Printf("stackOrg: %s", stackOrg)
+	fmt.Printf("stackOrg: %s\n", stackOrg)
 
-	_, path, _, ok := runtime.Caller(1)
+	_, path, _, ok := runtime.Caller(0)
 	if !ok {
 		Fail("Failed to determine current directory")
 	}
 	// Absolute path to base directory for the repository locally.
-	baseDir = filepath.FromSlash(filepath.Join(path, ".."))
+	baseDir = filepath.FromSlash(filepath.Join(path, "..", ".."))
+	fmt.Printf("Basedir: %s\n", baseDir)
 	commit, err := getCurrentCommit(baseDir)
 	if err != nil {
+		fmt.Printf("%+v", err)
 		Fail(fmt.Sprintf("Couldn't resolve current commit: %v", err))
 	}
 
+	fmt.Printf("Current commit is: %s\n", commit)
 	ctx := context.Background()
 	var pulumiAPISecret *corev1.Secret
 	var pulumiAWSSecret *corev1.Secret
@@ -196,7 +199,7 @@ var _ = Describe("Stack Controller", func() {
 		localSpec := pulumiv1alpha1.StackSpec{
 			Backend:         fmt.Sprintf("file://%s", backendDir),
 			Stack:           stackName,
-			ProjectRepo:     fmt.Sprintf(`file://%s.git`, baseDir),
+			ProjectRepo:     baseDir,
 			RepoDir:         "test/testdata/empty-stack",
 			Commit:          commit,
 			SecretsProvider: "passphrase",
@@ -252,7 +255,7 @@ var _ = Describe("Stack Controller", func() {
 				"aws:region": "us-east-2",
 			},
 			Stack:             stackName,
-			ProjectRepo:       fmt.Sprintf(`file://%s.git`, baseDir),
+			ProjectRepo:       baseDir,
 			RepoDir:           "test/testdata/test-s3-op-project",
 			Commit:            commit,
 			DestroyOnFinalize: true,
@@ -379,11 +382,12 @@ var _ = Describe("Stack Controller", func() {
 				"aws:region": "us-east-2",
 			},
 			Stack:             stackName,
-			ProjectRepo:       fmt.Sprintf(`file://%s.git`, baseDir),
+			ProjectRepo:       baseDir,
 			RepoDir:           "test/testdata/test-s3-op-project",
 			Commit:            commit,
 			DestroyOnFinalize: true,
 		}
+		fmt.Printf("ProjectRepo: %q\n", spec.RepoDir)
 
 		// Create stack
 		name := "stack-test-aws-s3-file-secrets"

--- a/test/testdata/test-s3-op-project/index.ts
+++ b/test/testdata/test-s3-op-project/index.ts
@@ -1,11 +1,19 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
-// Create an AWS resource (S3 Bucket)
+const cfg = new pulumi.Config("aws");
+// We will induce a change in region to test failures.
+const region = cfg.require("region");
+
+const prov = new aws.Provider("provider", {region: region as aws.Region});
 const names = [];
 for (let i = 0; i < 2; i++) {
+    // Create an AWS resource (S3 Bucket)
     const bucket = new aws.s3.Bucket(`my-bucket-${i}`, {
         acl: "public-read",
+        tags: {"region": region},
+    }, {
+        provider: prov,
     });
     names.push(bucket.id);
 }

--- a/test/testdata/test-s3-op-project/index.ts
+++ b/test/testdata/test-s3-op-project/index.ts
@@ -1,6 +1,5 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
-import * as awsx from "@pulumi/awsx";
 
 // Create an AWS resource (S3 Bucket)
 const names = [];

--- a/test/testdata/test-s3-op-project/package.json
+++ b/test/testdata/test-s3-op-project/package.json
@@ -5,7 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
-        "@pulumi/aws": "^4.0.0",
-        "@pulumi/awsx": "^0.20.0"
+        "@pulumi/aws": "^4.0.0"
     }
 }


### PR DESCRIPTION
Follow up from #176 - I missed a peer dependency conflict introduced due to awsx which isn't really used anyway.