### PR TITLE
Fix pip cache directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-(None)
+- Fix pip cache directory to be on emptyDir mount [#181[(https://github.com/pulumi/pulumi-kubernetes-operator/pull/181)
 
 ## 0.0.17 (2021-08-18)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN mkdir -p /home/pulumi-kubernetes-operator/.ssh \
 USER pulumi-kubernetes-operator
 
 ENV XDG_CONFIG_HOME=/tmp/.config
+ENV XDG_CACHE_HOME=/tmp/.cache
 ENV XDG_CONFIG_CACHE=/tmp/.cache
 ENV GOCACHE=/tmp/.cache/go-build
 ENV GOPATH=/tmp/.cache/go


### PR DESCRIPTION
Fixes #174 

This ensures pip cache dir is on /tmp (emptydir mount) and doesn't have permission issues.