### PR TITLE
No Permalink for Self Hosted Backends

### DIFF
--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -815,7 +815,8 @@ func (sess *reconcileStackSession) RefreshStack(expectNoChanges bool) (pulumiv1a
 	}
 	p, err := auto.GetPermalink(result.StdOut)
 	if err != nil {
-		return "", err
+		// Just log the error. No permalink suggests a backend that doesn't support permalinks.
+		sess.logger.Error(err, "No permalink found.", "Namespace", sess.namespace)
 	}
 	permalink := pulumiv1alpha1.Permalink(p)
 	return permalink, nil


### PR DESCRIPTION
### Proposed changes

Fixes a refresh loop where an error is returned because a permalink
doesn't exist with a self hosted backend.

### Related issues (optional)

Fixes #193 
