### PR TITLE
Fix stack refresh for BYO backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-(None)
+- Fix stack refresh for BYO backend [#200](https://github.com/pulumi/pulumi-kubernetes-operator/pull/200)
 
 ## 0.0.20 (2021-09-27)
 - Improve workdir cleanup logic [#195](https://github.com/pulumi/pulumi-kubernetes-operator/pull/195)

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -831,7 +831,8 @@ func (sess *reconcileStackSession) RefreshStack(expectNoChanges bool) (pulumiv1a
 	}
 	p, err := auto.GetPermalink(result.StdOut)
 	if err != nil {
-		return "", err
+		// Successful update but no permalink suggests a backend which doesn't support permalinks. Ignore.
+		sess.logger.Error(err, "No permalink found.", "Namespace", sess.namespace)
 	}
 	permalink := pulumiv1alpha1.Permalink(p)
 	return permalink, nil


### PR DESCRIPTION
Signed-off-by: Liam White <liam@tetrate.io>

### Proposed changes

As discussed on Slack, refresh doesn't work for non-Pulumi backends. This changes the refresh behaviour to that of update when using a non-Pulumi backend.
