### PR TITLE
Nested secret outputs are now masked by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 - Make max reconciles configurable. Users can now set `MAX_CONCURRENT_RECONCILES` to limit concurrent reconciles (defaults to 10). [#213](https://github.com/pulumi/pulumi-kubernetes-operator/pull/213/)
+- Nested secret outputs are now masked by default. [#216](https://github.com/pulumi/pulumi-kubernetes-operator/pull/216/)
 
 ## 0.0.21 (2021-10-04)
 - Fix clean up logic on reconcile [#203](https://github.com/pulumi/pulumi-kubernetes-operator/pull/203)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/common v0.30.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
-	github.com/pulumi/pulumi/sdk/v3 v3.13.2
+	github.com/pulumi/pulumi/sdk/v3 v3.14.1-0.20211008214310-a9a62bd76177
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/whilp/git-urls v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -878,8 +878,8 @@ github.com/prometheus/prometheus v0.0.0-20180315085919-58e2a31db8de/go.mod h1:oA
 github.com/prometheus/prometheus v1.8.2-0.20200110114423-1e64d757f711/go.mod h1:7U90zPoLkWjEIQcy/rweQla82OCTUzxVHE51G3OhJbI=
 github.com/prometheus/prometheus v2.3.2+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi/sdk/v3 v3.13.2 h1:WACuLmogYmUubf3jKcnkN9ACJ5G+3PLSPkCI86DpY9k=
-github.com/pulumi/pulumi/sdk/v3 v3.13.2/go.mod h1:aT7YmFdR6/T7tp2tMIZ68WRD1Xyv5a6Y4BhsuaCNpW0=
+github.com/pulumi/pulumi/sdk/v3 v3.14.1-0.20211008214310-a9a62bd76177 h1:H5zn9PMJKoOHHKCGCRX74FAoItkA8/M1IItFcwutv2g=
+github.com/pulumi/pulumi/sdk/v3 v3.14.1-0.20211008214310-a9a62bd76177/go.mod h1:aT7YmFdR6/T7tp2tMIZ68WRD1Xyv5a6Y4BhsuaCNpW0=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/robfig/cron v0.0.0-20170526150127-736158dc09e1/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=

--- a/test/stack_controller_test.go
+++ b/test/stack_controller_test.go
@@ -246,9 +246,10 @@ var _ = Describe("Stack Controller", func() {
 		}, timeout, interval).Should(BeTrue())
 		// Validate outputs.
 		Expect(fetched.Status.Outputs).Should(BeEquivalentTo(pulumiv1alpha1.StackOutputs{
-			"region":      v1.JSON{Raw: []byte(`"us-west-2"`)},
-			"notSoSecret": v1.JSON{Raw: []byte(`"safe"`)},
-			"secretVal":   v1.JSON{Raw: []byte(`"[secret]"`)},
+			"region":       v1.JSON{Raw: []byte(`"us-west-2"`)},
+			"notSoSecret":  v1.JSON{Raw: []byte(`"safe"`)},
+			"secretVal":    v1.JSON{Raw: []byte(`"[secret]"`)},
+			"nestedSecret": v1.JSON{Raw: []byte(`"[secret]"`)},
 		}))
 
 		// Delete the Stack

--- a/test/testdata/empty-stack/index.ts
+++ b/test/testdata/empty-stack/index.ts
@@ -9,3 +9,8 @@ export const notSoSecret = pulumi.output("safe")
 export const secretVal = pulumi.secret({
     "val" : "very secret"
 });
+
+export const nestedSecret = {
+    "plain": "foo",
+    "secret": pulumi.secret("bar"),
+};


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fix #204 
<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
