### PR TITLE
Get bash from env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 GIT_COMMIT := $(shell git rev-parse --short HEAD)
 VERSION := $(GIT_COMMIT)
 PUBLISH_IMAGE_NAME := pulumi/pulumi-kubernetes-operator

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o nounset -o errexit -o pipefail
 
 export GO111MODULE=on
@@ -19,5 +19,5 @@ if [ "$build_static" == "static" ]; then
 fi
 
 # Build the operator.
-/bin/bash -c "go build -o $name -ldflags \"${ldflags:-}\" $extra_args ./cmd/manager/main.go"
+/usr/bin/env bash -c "go build -o $name -ldflags \"${ldflags:-}\" $extra_args ./cmd/manager/main.go"
 chmod +x "$name"

--- a/scripts/ci-cluster-create.sh
+++ b/scripts/ci-cluster-create.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o nounset -o errexit -o pipefail
 
 echo Creating ephemeral Kubernetes cluster for CI testing...

--- a/scripts/ci-cluster-destroy.sh
+++ b/scripts/ci-cluster-destroy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o nounset -o errexit -o pipefail
 
 echo Deleting ephemeral Kubernetes cluster...

--- a/scripts/generate_crds.sh
+++ b/scripts/generate_crds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cwd=$(dirname "$0")


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
This PR fixes the shebang on all the scripts. The scripts currently call `/bin/bash` which is not a standard location for the bash binary. For example, because I'm using NixOS, my bash binary is located in `/nix/store/${hash}-bash-interactive-5.1-p8/bin/bash`.
<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
