### PR TITLE
Add some basic stack events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 - Default timestamps are now iso8601 in logs. Remove `"--zap-time-encoding=iso8601"` line from deployment spec to revert to old timestamps [#234](https://github.com/pulumi/pulumi-kubernetes-operator/pull/234)
+- Add some basic event publishing [#235](https://github.com/pulumi/pulumi-kubernetes-operator/pull/235)
 
 ## 1.1.0 (2021-10-27)
 - Avoid double install of dependencies [#230](https://github.com/pulumi/pulumi-kubernetes-operator/pull/230)

--- a/pkg/apis/pulumi/v1/events.go
+++ b/pkg/apis/pulumi/v1/events.go
@@ -1,0 +1,81 @@
+// Copyright 2021, Pulumi Corporation.  All rights reserved.
+
+package v1
+
+// StackEvent is a manifestation of a Kubernetes event emitted by the stack controller.
+type StackEvent struct {
+	reason    StackEventReason
+	eventType StackEventType
+}
+
+func (e StackEvent) EventType() string {
+	return string(e.eventType)
+}
+
+func (e StackEvent) Reason() string {
+	return string(e.reason)
+}
+
+// StackEventType tracks the types supported by the Kubernetes EventRecorder interface in k8s.io/client-go/tools/record
+type StackEventType string
+
+const (
+	EventTypeNormal  StackEventType = "Normal"
+	EventTypeWarning StackEventType = "Warning"
+)
+
+// StackEventReason reflects distinct categorizations of events emitted by the stack controller.
+type StackEventReason string
+
+const (
+	// Warnings
+
+	StackConfigInvalid          StackEventReason = "StackConfigInvalid"
+	StackInitializationFailure  StackEventReason = "StackInitializationFailure"
+	StackGitAuthFailure         StackEventReason = "StackGitAuthenticationFailure"
+	StackUpdateFailure          StackEventReason = "StackUpdateFailure"
+	StackUpdateConflictDetected StackEventReason = "StackUpdateConflictDetected"
+	StackOutputRetrievalFailure StackEventReason = "StackOutputRetrievalFailure"
+
+	// Normals
+
+	StackUpdateDetected   StackEventReason = "StackUpdateDetected"
+	StackNotFound         StackEventReason = "StackNotFound"
+	StackUpdateSuccessful StackEventReason = "StackCreated"
+)
+
+func StackConfigInvalidEvent() StackEvent {
+	return StackEvent{eventType: EventTypeWarning, reason: StackConfigInvalid}
+}
+
+func StackInitializationFailureEvent() StackEvent {
+	return StackEvent{eventType: EventTypeWarning, reason: StackInitializationFailure}
+}
+
+func StackGitAuthFailureEvent() StackEvent {
+	return StackEvent{eventType: EventTypeWarning, reason: StackGitAuthFailure}
+}
+
+func StackUpdateFailureEvent() StackEvent {
+	return StackEvent{eventType: EventTypeWarning, reason: StackUpdateFailure}
+}
+
+func StackUpdateConflictDetectedEvent() StackEvent {
+	return StackEvent{eventType: EventTypeWarning, reason: StackUpdateConflictDetected}
+}
+
+func StackOutputRetrievalFailureEvent() StackEvent {
+	return StackEvent{eventType: EventTypeWarning, reason: StackOutputRetrievalFailure}
+}
+
+func StackUpdateDetectedEvent() StackEvent {
+	return StackEvent{eventType: EventTypeNormal, reason: StackUpdateDetected}
+}
+
+func StackNotFoundEvent() StackEvent {
+	return StackEvent{eventType: EventTypeNormal, reason: StackNotFound}
+}
+
+func StackUpdateSuccessfulEvent() StackEvent {
+	return StackEvent{eventType: EventTypeNormal, reason: StackUpdateSuccessful}
+}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes
This change adds support for some basic event publishing. With this change, you can do the following:
```
$ kubectl describe stacks

...
Events:
  Type     Reason                      Age   From              Message
  ----     ------                      ----  ----              -------
  Warning  StackInitializationFailure  1s    stack-controller  Failed to initialize stack: failed to create and/or select stack: s3backend.s3-op-project: failed to create stack: exit status 255
code: 255
stdout:
stderr: error: could not create stack: An IO error occurred while writing the new snapshot file: blob (key ".pulumi/stacks/s3backend.s3-op-project.json") (code=Unknown): InvalidBucketName: The specified bucket is not valid.
  status code: 400, request id: 9ZT47FVPDT2FR95Y, host id
```
This should significantly improve the experience of debugging issues with failing stacks.

<!--Give us a brief description of what you've done and what it solves. -->

### Related issues (optional)
Fixes #73 

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
