### PR TITLE
metrics: use pulumiv1 api

### DIFF
--- a/pkg/controller/stack/metrics.go
+++ b/pkg/controller/stack/metrics.go
@@ -5,7 +5,7 @@ package stack
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/pulumi/pulumi-kubernetes-operator/pkg/apis/pulumi/shared"
-	pulumiv1alpha1 "github.com/pulumi/pulumi-kubernetes-operator/pkg/apis/pulumi/v1alpha1"
+	pulumiv1 "github.com/pulumi/pulumi-kubernetes-operator/pkg/apis/pulumi/v1"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -43,12 +43,12 @@ func newStackCallback(obj interface{}) {
 }
 
 func updateStackCallback(oldObj, newObj interface{}) {
-	oldStack, ok := oldObj.(*pulumiv1alpha1.Stack)
+	oldStack, ok := oldObj.(*pulumiv1.Stack)
 	if !ok {
 		return
 	}
 
-	newStack, ok := newObj.(*pulumiv1alpha1.Stack)
+	newStack, ok := newObj.(*pulumiv1.Stack)
 	if !ok {
 		return
 	}


### PR DESCRIPTION
### Proposed changes

This fixes the `stacks_failing` metric. I believe v1alpha1 is being deprecated and without this the `stacks_failing` metric isn't set.