### PR TITLE
fix: use runtime namespace when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Default namespace for resources that don't provide one is now the service accounts namespace (where the operator is likely running) instead of "default"
+
 ## 1.3.0 (2021-12-15)
 - Add ability to resync stacks periodically [#243](https://github.com/pulumi/pulumi-kubernetes-operator/pull/243)
 - Bump to Pulumi v3.19.0 [#246](https://github.com/pulumi/pulumi-kubernetes-operator/pull/246)

--- a/deploy/operator_template.yaml
+++ b/deploy/operator_template.yaml
@@ -42,4 +42,6 @@ spec:
               value: "5m"
             - name: MAX_CONCURRENT_RECONCILES
               value: "10"
+            - name: PULUMI_INFER_NAMESPACE
+              value: "1"
       terminationGracePeriodSeconds: 300 # Should be same or larger than GRACEFUL_SHUTDOWN_TIMEOUT_DURATION

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -1205,6 +1205,8 @@ func contains(list []string, s string) bool {
 func setupInClusterKubeconfig() error {
 	const certFp = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	const tokenFp = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	const namespaceFp = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
 	kubeFp := os.ExpandEnv("$HOME/.kube")
 	kubeconfigFp := fmt.Sprintf("%s/config", kubeFp)
 
@@ -1215,6 +1217,10 @@ func setupInClusterKubeconfig() error {
 	token, err := waitForFile(tokenFp)
 	if err != nil {
 		return errors.Wrap(err, "failed to open in-cluster ServiceAccount token")
+	}
+	namespace, err := waitForFile(namespaceFp)
+	if err != nil {
+		return errors.Wrap(err, "failed to open in-cluster ServiceAccount namespace")
 	}
 
 	// Compute the kubeconfig using the cert and token.
@@ -1229,6 +1235,7 @@ contexts:
 - context:
     cluster: local
     user: local
+    namespace: %s
   name: local
 current-context: local
 kind: Config
@@ -1236,7 +1243,7 @@ users:
 - name: local
   user:
     token: %s
-`, string(base64.StdEncoding.EncodeToString(cert)), os.ExpandEnv("$KUBERNETES_PORT_443_TCP_ADDR"), string(token))
+`, string(base64.StdEncoding.EncodeToString(cert)), os.ExpandEnv("$KUBERNETES_PORT_443_TCP_ADDR"), string(namespace), string(token))
 
 	err = os.Mkdir(os.ExpandEnv(kubeFp), 0755)
 	if err != nil {

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -1235,7 +1235,7 @@ contexts:
 - context:
     cluster: local
     user: local
-    namespace: %s
+    %s
   name: local
 current-context: local
 kind: Config
@@ -1243,7 +1243,7 @@ users:
 - name: local
   user:
     token: %s
-`, string(base64.StdEncoding.EncodeToString(cert)), os.ExpandEnv("$KUBERNETES_PORT_443_TCP_ADDR"), string(namespace), string(token))
+`, string(base64.StdEncoding.EncodeToString(cert)), os.ExpandEnv("$KUBERNETES_PORT_443_TCP_ADDR"), inferNamespace(string(namespace)), string(token))
 
 	err = os.Mkdir(os.ExpandEnv(kubeFp), 0755)
 	if err != nil {

--- a/pkg/controller/stack/utils.go
+++ b/pkg/controller/stack/utils.go
@@ -1,3 +1,4 @@
+// Copyright 2021, Pulumi Corporation.  All rights reserved.
 package stack
 
 import (

--- a/pkg/controller/stack/utils.go
+++ b/pkg/controller/stack/utils.go
@@ -1,0 +1,23 @@
+package stack
+
+import (
+	"fmt"
+	"os"
+)
+
+// Environment variable to toggle namespace behavior
+const INFERNS = "PULUMI_INFER_NAMESPACE"
+
+// inferNamespace returns the namespace that is passed in when
+// the environment variable is set.
+// This is used to maintain the old behavior of not using
+// the service-account namespace when using in-cluster config.
+// Ideally, this env will be removed and become the default in
+// the future.
+func inferNamespace(namespace string) string {
+	if os.Getenv(INFERNS) != "" {
+		return fmt.Sprintf("namespace: %s", namespace)
+	}
+
+	return ""
+}

--- a/pkg/controller/stack/utils_test.go
+++ b/pkg/controller/stack/utils_test.go
@@ -1,0 +1,21 @@
+package stack
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_WithInferNamespace(t *testing.T) {
+
+	os.Setenv(INFERNS, "1")
+	defer os.Unsetenv(INFERNS)
+
+	assert.Equal(t, "namespace: test-ns", inferNamespace("test-ns"))
+
+}
+
+func Test_WithoutInferNamespace(t *testing.T) {
+	assert.Equal(t, "", inferNamespace("test-ns"))
+}

--- a/pkg/controller/stack/utils_test.go
+++ b/pkg/controller/stack/utils_test.go
@@ -1,3 +1,4 @@
+// Copyright 2021, Pulumi Corporation.  All rights reserved.
 package stack
 
 import (


### PR DESCRIPTION
When running the operator in a namespace, stack resources that do not contain an explicit namespace are attempted to be created in the default namespace; which is rather strange behaviour.

This PR will infer the default namespace from the service account under which the pod is running.

### Proposed changes

This change has the operator set the default namespace to that of the service account under which it's running.

### Related issues (optional)

N/A
