### PR TITLE
fix: resolve namespace correctly for envRef secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## HEAD (Unreleased)
+
+- Use configured namespace for envRef Secrets, instead of defaulting to 'default'
+
 ## 1.4.0 (2022-02-02)
 
 **BREAKING CHANGES**

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -567,7 +567,7 @@ func (sess *reconcileStackSession) resolveResourceRef(ref *shared.ResourceRef) (
 			config := &corev1.Secret{}
 			namespace := ref.SecretRef.Namespace
 			if namespace == "" {
-				namespace = "default"
+				namespace = sess.namespace
 			}
 			if err := sess.getLatestResource(config, types.NamespacedName{Name: ref.SecretRef.Name, Namespace: namespace}); err != nil {
 				return "", errors.Wrapf(err, "Namespace=%s Name=%s", ref.SecretRef.Namespace, ref.SecretRef.Name)


### PR DESCRIPTION
Found another hard-coded default namespace, this meant all `envRef` secrets, such as `PULUMI_ACCESS_TOKEN`, where being looked for in `default` when unprovided by the Stack CR.