### PR TITLE
Add the ability to deploy the operator via a Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-- Add the ability to deploy the operator via a Helm chart
+- Add the ability to deploy the operator via a Helm chart [#261](https://github.com/pulumi/pulumi-kubernetes-operator/pull/261)
 
 ## 1.5.0 (2022-03-14)
 - Use configured namespace for envRef Secrets, instead of defaulting to 'default'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-(None)
+- Add the ability to deploy the operator via a Helm chart
 
 ## 1.5.0 (2022-03-14)
 - Use configured namespace for envRef Secrets, instead of defaulting to 'default'

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ To learn more about the Pulumi Kubernetes Operator visit the [Pulumi documentati
       - [Login to Your Chosen State Backend](#login-to-your-chosen-state-backend)
   - [Deploy the Operator](#deploy-the-operator)
     - [Using kubectl](#using-kubectl)
+    - [Using Helm](#using-helm)
     - [Using Pulumi](#using-pulumi)
   - [Create Pulumi Stack CustomResources](#create-pulumi-stack-customresources)
     - [Using kubectl](#using-kubectl-1)
@@ -108,6 +109,11 @@ Deploy the API resources for the operator.
 ```bash
 kubectl apply -f deploy/yaml
 ```
+
+### Using Helm
+1. Go to the [`deploy/chart`](deploy/chart/values.yaml) directory.
+2. (Optional) Adjust the default values as desired.
+3. Run `helm upgrade --install pulumi-kubernetes-operator --wait .`
 
 ### Using Pulumi
 

--- a/deploy/chart/.helmignore
+++ b/deploy/chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: pulumi-kubernetes-operator
+description: A Helm chart for the Pulumi Kubernetes Operator
+keywords:
+  - pulumi
+sources:
+  - https://github.com/pulumi/pulumi-kubernetes-operator
+icon: https://www.pulumi.com/logos/brand/avatar-on-white.svg
+version: v0.1.0
+appVersion: v1.5.0

--- a/deploy/chart/crds/pulumi.com_stacks.yaml
+++ b/deploy/chart/crds/pulumi.com_stacks.yaml
@@ -1,0 +1,1044 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: stacks.pulumi.com
+spec:
+  group: pulumi.com
+  names:
+    kind: Stack
+    listKind: StackList
+    plural: stacks
+    singular: stack
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: Stack is the Schema for the stacks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StackSpec defines the desired state of Pulumi Stack being managed by this operator.
+            properties:
+              accessTokenSecret:
+                description: '(optional) AccessTokenSecret is the name of a secret containing the PULUMI_ACCESS_TOKEN for Pulumi access. Deprecated: use EnvRefs with a "secret" entry with the key PULUMI_ACCESS_TOKEN instead.'
+                type: string
+              backend:
+                description: '(optional) Backend is an optional backend URL to use for all Pulumi operations.<br/> Examples:<br/>   - Pulumi Service:              "https://app.pulumi.com" (default)<br/>   - Self-managed Pulumi Service: "https://pulumi.acmecorp.com" <br/>   - Local:                       "file://./einstein" <br/>   - AWS:                         "s3://<my-pulumi-state-bucket>" <br/>   - Azure:                       "azblob://<my-pulumi-state-bucket>" <br/>   - GCP:                         "gs://<my-pulumi-state-bucket>" <br/> See: https://www.pulumi.com/docs/intro/concepts/state/'
+                type: string
+              branch:
+                description: (optional) Branch is the branch name to deploy, either the simple or fully qualified ref name, e.g. refs/heads/master. This is mutually exclusive with the Commit setting. Either value needs to be specified. When specified, the operator will periodically poll to check if the branch has any new commits. The frequency of the polling is configurable through ResyncFrequencySeconds, defaulting to every 60 seconds.
+                type: string
+              commit:
+                description: (optional) Commit is the hash of the commit to deploy. If used, HEAD will be in detached mode. This is mutually exclusive with the Branch setting. Either value needs to be specified.
+                type: string
+              config:
+                additionalProperties:
+                  type: string
+                description: (optional) Config is the configuration for this stack, which can be optionally specified inline. If this is omitted, configuration is assumed to be checked in and taken from the source repository.
+                type: object
+              continueResyncOnCommitMatch:
+                description: (optional) ContinueResyncOnCommitMatch - when true - informs the operator to continue trying to update stacks even if the commit matches. This might be useful in environments where Pulumi programs have dynamic elements for example, calls to internal APIs where GitOps style commit tracking is not sufficient. Defaults to false, i.e. when a particular commit is successfully run, the operator will not attempt to rerun the program at that commit again.
+                type: boolean
+              destroyOnFinalize:
+                description: (optional) DestroyOnFinalize can be set to true to destroy the stack completely upon deletion of the CRD.
+                type: boolean
+              envRefs:
+                additionalProperties:
+                  description: ResourceRef identifies a resource from which information can be loaded. Environment variables, files on the filesystem, Kubernetes secrets and literal strings are currently supported.
+                  properties:
+                    env:
+                      description: Env selects an environment variable set on the operator process
+                      properties:
+                        name:
+                          description: Name of the environment variable
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    filesystem:
+                      description: FileSystem selects a file on the operator's file system
+                      properties:
+                        path:
+                          description: Path on the filesystem to use to load information from.
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    literal:
+                      description: LiteralRef refers to a literal value
+                      properties:
+                        value:
+                          description: Value to load
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    secret:
+                      description: SecretRef refers to a Kubernetes secret
+                      properties:
+                        key:
+                          description: Key within the secret to use.
+                          type: string
+                        name:
+                          description: Name of the secret
+                          type: string
+                        namespace:
+                          description: Namespace where the secret is stored. Defaults to 'default' if omitted.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type:
+                      description: 'SelectorType is required and signifies the type of selector. Must be one of: Env, FS, Secret, Literal'
+                      type: string
+                  required:
+                  - type
+                  type: object
+                description: (optional) EnvRefs is an optional map containing environment variables as keys and stores descriptors to where the variables' values should be loaded from (one of literal, environment variable, file on the filesystem, or Kubernetes secret) as values.
+                type: object
+              envSecrets:
+                description: '(optional) SecretEnvs is an optional array of secret names containing environment variables to set. Deprecated: use EnvRefs instead.'
+                items:
+                  type: string
+                type: array
+              envs:
+                description: '(optional) Envs is an optional array of config maps containing environment variables to set. Deprecated: use EnvRefs instead.'
+                items:
+                  type: string
+                type: array
+              expectNoRefreshChanges:
+                description: (optional) ExpectNoRefreshChanges can be set to true if a stack is not expected to have changes during a refresh before the update is run. This could occur, for example, is a resource's state is changing outside of Pulumi (e.g., metadata, timestamps).
+                type: boolean
+              gitAuth:
+                description: '(optional) GitAuth allows configuring git authentication options There are 3 different authentication options:   * SSH private key (and its optional password)   * Personal access token   * Basic auth username and password Only one authentication mode will be considered if more than one option is specified, with ssh private key/password preferred first, then personal access token, and finally basic auth credentials.'
+                properties:
+                  accessToken:
+                    description: ResourceRef identifies a resource from which information can be loaded. Environment variables, files on the filesystem, Kubernetes secrets and literal strings are currently supported.
+                    properties:
+                      env:
+                        description: Env selects an environment variable set on the operator process
+                        properties:
+                          name:
+                            description: Name of the environment variable
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      filesystem:
+                        description: FileSystem selects a file on the operator's file system
+                        properties:
+                          path:
+                            description: Path on the filesystem to use to load information from.
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      literal:
+                        description: LiteralRef refers to a literal value
+                        properties:
+                          value:
+                            description: Value to load
+                            type: string
+                        required:
+                        - value
+                        type: object
+                      secret:
+                        description: SecretRef refers to a Kubernetes secret
+                        properties:
+                          key:
+                            description: Key within the secret to use.
+                            type: string
+                          name:
+                            description: Name of the secret
+                            type: string
+                          namespace:
+                            description: Namespace where the secret is stored. Defaults to 'default' if omitted.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      type:
+                        description: 'SelectorType is required and signifies the type of selector. Must be one of: Env, FS, Secret, Literal'
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  basicAuth:
+                    description: BasicAuth configures git authentication through basic auth — i.e. username and password. Both UserName and Password are required.
+                    properties:
+                      password:
+                        description: ResourceRef identifies a resource from which information can be loaded. Environment variables, files on the filesystem, Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Defaults to 'default' if omitted.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      userName:
+                        description: ResourceRef identifies a resource from which information can be loaded. Environment variables, files on the filesystem, Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Defaults to 'default' if omitted.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - password
+                    - userName
+                    type: object
+                  sshAuth:
+                    description: SSHAuth configures ssh-based auth for git authentication. SSHPrivateKey is required but password is optional.
+                    properties:
+                      password:
+                        description: ResourceRef identifies a resource from which information can be loaded. Environment variables, files on the filesystem, Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Defaults to 'default' if omitted.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      sshPrivateKey:
+                        description: ResourceRef identifies a resource from which information can be loaded. Environment variables, files on the filesystem, Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Defaults to 'default' if omitted.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - sshPrivateKey
+                    type: object
+                type: object
+              gitAuthSecret:
+                description: '(optional) GitAuthSecret is the the name of a secret containing an authentication option for the git repository. There are 3 different authentication options:   * Personal access token   * SSH private key (and it''s optional password)   * Basic auth username and password Only one authentication mode will be considered if more than one option is specified, with ssh private key/password preferred first, then personal access token, and finally basic auth credentials. Deprecated. Use GitAuth instead.'
+                type: string
+              projectRepo:
+                description: ProjectRepo is the git source control repository from which we fetch the project code and configuration.
+                type: string
+              refresh:
+                description: (optional) Refresh can be set to true to refresh the stack before it is updated.
+                type: boolean
+              repoDir:
+                description: (optional) RepoDir is the directory to work from in the project's source repository where Pulumi.yaml is located. It is used in case Pulumi.yaml is not in the project source root.
+                type: string
+              resyncFrequencySeconds:
+                description: (optional) ResyncFrequencySeconds when set to a non-zero value, triggers a resync of the stack at the specified frequency even if no changes to the custom-resource are detected. If branch tracking is enabled (branch is non-empty), commit polling will occur at this frequency. The minimal resync frequency supported is 60 seconds.
+                format: int64
+                type: integer
+              retryOnUpdateConflict:
+                description: (optional) RetryOnUpdateConflict issues a stack update retry reconciliation loop in the event that the update hits a HTTP 409 conflict due to another update in progress. This is only recommended if you are sure that the stack updates are idempotent, and if you are willing to accept retry loops until all spawned retries succeed. This will also create a more populated, and randomized activity timeline for the stack in the Pulumi Service.
+                type: boolean
+              secrets:
+                additionalProperties:
+                  type: string
+                description: '(optional) Secrets is the secret configuration for this stack, which can be optionally specified inline. If this is omitted, secrets configuration is assumed to be checked in and taken from the source repository. Deprecated: use SecretRefs instead.'
+                type: object
+              secretsProvider:
+                description: '(optional) SecretsProvider is used to initialize a Stack with alternative encryption. Examples:   - AWS:   "awskms:///arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34bc-56ef-1234567890ab?region=us-east-1"   - Azure: "azurekeyvault://acmecorpvault.vault.azure.net/keys/mykeyname"   - GCP:   "gcpkms://projects/MYPROJECT/locations/MYLOCATION/keyRings/MYKEYRING/cryptoKeys/MYKEY"   - See: https://www.pulumi.com/docs/intro/concepts/secrets/#initializing-a-stack-with-alternative-encryption'
+                type: string
+              secretsRef:
+                additionalProperties:
+                  description: ResourceRef identifies a resource from which information can be loaded. Environment variables, files on the filesystem, Kubernetes secrets and literal strings are currently supported.
+                  properties:
+                    env:
+                      description: Env selects an environment variable set on the operator process
+                      properties:
+                        name:
+                          description: Name of the environment variable
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    filesystem:
+                      description: FileSystem selects a file on the operator's file system
+                      properties:
+                        path:
+                          description: Path on the filesystem to use to load information from.
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    literal:
+                      description: LiteralRef refers to a literal value
+                      properties:
+                        value:
+                          description: Value to load
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    secret:
+                      description: SecretRef refers to a Kubernetes secret
+                      properties:
+                        key:
+                          description: Key within the secret to use.
+                          type: string
+                        name:
+                          description: Name of the secret
+                          type: string
+                        namespace:
+                          description: Namespace where the secret is stored. Defaults to 'default' if omitted.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type:
+                      description: 'SelectorType is required and signifies the type of selector. Must be one of: Env, FS, Secret, Literal'
+                      type: string
+                  required:
+                  - type
+                  type: object
+                description: (optional) SecretRefs is the secret configuration for this stack which can be specified through ResourceRef. If this is omitted, secrets configuration is assumed to be checked in and taken from the source repository.
+                type: object
+              stack:
+                description: Stack is the fully qualified name of the stack to deploy (<org>/<stack>).
+                type: string
+              useLocalStackOnly:
+                description: (optional) UseLocalStackOnly can be set to true to prevent the operator from creating stacks that do not exist in the tracking git repo. The default behavior is to create a stack if it doesn't exist.
+                type: boolean
+            required:
+            - projectRepo
+            - stack
+            type: object
+          status:
+            description: StackStatus defines the observed state of Stack
+            properties:
+              lastUpdate:
+                description: LastUpdate contains details of the status of the last update.
+                properties:
+                  lastAttemptedCommit:
+                    description: Last commit attempted
+                    type: string
+                  lastResyncTime:
+                    description: LastResyncTime contains a timestamp for the last time a resync of the stack took place.
+                    format: date-time
+                    type: string
+                  lastSuccessfulCommit:
+                    description: Last commit successfully applied
+                    type: string
+                  permalink:
+                    description: Permalink is the Pulumi Console URL of the stack operation.
+                    type: string
+                  state:
+                    description: State is the state of the stack update - one of `succeeded` or `failed`
+                    type: string
+                type: object
+              outputs:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: Outputs contains the exported stack output variables resulting from a deployment.
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'Stack is the Schema for the stacks API. Deprecated: Note Stacks from pulumi.com/v1alpha1 is deprecated in favor of pulumi.com/v1. It is completely backward compatible. Users are strongly encouraged to switch to pulumi.com/v1.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StackSpec defines the desired state of Pulumi Stack being managed by this operator.
+            properties:
+              accessTokenSecret:
+                description: '(optional) AccessTokenSecret is the name of a secret containing the PULUMI_ACCESS_TOKEN for Pulumi access. Deprecated: use EnvRefs with a "secret" entry with the key PULUMI_ACCESS_TOKEN instead.'
+                type: string
+              backend:
+                description: '(optional) Backend is an optional backend URL to use for all Pulumi operations.<br/> Examples:<br/>   - Pulumi Service:              "https://app.pulumi.com" (default)<br/>   - Self-managed Pulumi Service: "https://pulumi.acmecorp.com" <br/>   - Local:                       "file://./einstein" <br/>   - AWS:                         "s3://<my-pulumi-state-bucket>" <br/>   - Azure:                       "azblob://<my-pulumi-state-bucket>" <br/>   - GCP:                         "gs://<my-pulumi-state-bucket>" <br/> See: https://www.pulumi.com/docs/intro/concepts/state/'
+                type: string
+              branch:
+                description: (optional) Branch is the branch name to deploy, either the simple or fully qualified ref name, e.g. refs/heads/master. This is mutually exclusive with the Commit setting. Either value needs to be specified. When specified, the operator will periodically poll to check if the branch has any new commits. The frequency of the polling is configurable through ResyncFrequencySeconds, defaulting to every 60 seconds.
+                type: string
+              commit:
+                description: (optional) Commit is the hash of the commit to deploy. If used, HEAD will be in detached mode. This is mutually exclusive with the Branch setting. Either value needs to be specified.
+                type: string
+              config:
+                additionalProperties:
+                  type: string
+                description: (optional) Config is the configuration for this stack, which can be optionally specified inline. If this is omitted, configuration is assumed to be checked in and taken from the source repository.
+                type: object
+              continueResyncOnCommitMatch:
+                description: (optional) ContinueResyncOnCommitMatch - when true - informs the operator to continue trying to update stacks even if the commit matches. This might be useful in environments where Pulumi programs have dynamic elements for example, calls to internal APIs where GitOps style commit tracking is not sufficient. Defaults to false, i.e. when a particular commit is successfully run, the operator will not attempt to rerun the program at that commit again.
+                type: boolean
+              destroyOnFinalize:
+                description: (optional) DestroyOnFinalize can be set to true to destroy the stack completely upon deletion of the CRD.
+                type: boolean
+              envRefs:
+                additionalProperties:
+                  description: ResourceRef identifies a resource from which information can be loaded. Environment variables, files on the filesystem, Kubernetes secrets and literal strings are currently supported.
+                  properties:
+                    env:
+                      description: Env selects an environment variable set on the operator process
+                      properties:
+                        name:
+                          description: Name of the environment variable
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    filesystem:
+                      description: FileSystem selects a file on the operator's file system
+                      properties:
+                        path:
+                          description: Path on the filesystem to use to load information from.
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    literal:
+                      description: LiteralRef refers to a literal value
+                      properties:
+                        value:
+                          description: Value to load
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    secret:
+                      description: SecretRef refers to a Kubernetes secret
+                      properties:
+                        key:
+                          description: Key within the secret to use.
+                          type: string
+                        name:
+                          description: Name of the secret
+                          type: string
+                        namespace:
+                          description: Namespace where the secret is stored. Defaults to 'default' if omitted.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type:
+                      description: 'SelectorType is required and signifies the type of selector. Must be one of: Env, FS, Secret, Literal'
+                      type: string
+                  required:
+                  - type
+                  type: object
+                description: (optional) EnvRefs is an optional map containing environment variables as keys and stores descriptors to where the variables' values should be loaded from (one of literal, environment variable, file on the filesystem, or Kubernetes secret) as values.
+                type: object
+              envSecrets:
+                description: '(optional) SecretEnvs is an optional array of secret names containing environment variables to set. Deprecated: use EnvRefs instead.'
+                items:
+                  type: string
+                type: array
+              envs:
+                description: '(optional) Envs is an optional array of config maps containing environment variables to set. Deprecated: use EnvRefs instead.'
+                items:
+                  type: string
+                type: array
+              expectNoRefreshChanges:
+                description: (optional) ExpectNoRefreshChanges can be set to true if a stack is not expected to have changes during a refresh before the update is run. This could occur, for example, is a resource's state is changing outside of Pulumi (e.g., metadata, timestamps).
+                type: boolean
+              gitAuth:
+                description: '(optional) GitAuth allows configuring git authentication options There are 3 different authentication options:   * SSH private key (and its optional password)   * Personal access token   * Basic auth username and password Only one authentication mode will be considered if more than one option is specified, with ssh private key/password preferred first, then personal access token, and finally basic auth credentials.'
+                properties:
+                  accessToken:
+                    description: ResourceRef identifies a resource from which information can be loaded. Environment variables, files on the filesystem, Kubernetes secrets and literal strings are currently supported.
+                    properties:
+                      env:
+                        description: Env selects an environment variable set on the operator process
+                        properties:
+                          name:
+                            description: Name of the environment variable
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      filesystem:
+                        description: FileSystem selects a file on the operator's file system
+                        properties:
+                          path:
+                            description: Path on the filesystem to use to load information from.
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      literal:
+                        description: LiteralRef refers to a literal value
+                        properties:
+                          value:
+                            description: Value to load
+                            type: string
+                        required:
+                        - value
+                        type: object
+                      secret:
+                        description: SecretRef refers to a Kubernetes secret
+                        properties:
+                          key:
+                            description: Key within the secret to use.
+                            type: string
+                          name:
+                            description: Name of the secret
+                            type: string
+                          namespace:
+                            description: Namespace where the secret is stored. Defaults to 'default' if omitted.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      type:
+                        description: 'SelectorType is required and signifies the type of selector. Must be one of: Env, FS, Secret, Literal'
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  basicAuth:
+                    description: BasicAuth configures git authentication through basic auth — i.e. username and password. Both UserName and Password are required.
+                    properties:
+                      password:
+                        description: ResourceRef identifies a resource from which information can be loaded. Environment variables, files on the filesystem, Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Defaults to 'default' if omitted.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      userName:
+                        description: ResourceRef identifies a resource from which information can be loaded. Environment variables, files on the filesystem, Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Defaults to 'default' if omitted.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - password
+                    - userName
+                    type: object
+                  sshAuth:
+                    description: SSHAuth configures ssh-based auth for git authentication. SSHPrivateKey is required but password is optional.
+                    properties:
+                      password:
+                        description: ResourceRef identifies a resource from which information can be loaded. Environment variables, files on the filesystem, Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Defaults to 'default' if omitted.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      sshPrivateKey:
+                        description: ResourceRef identifies a resource from which information can be loaded. Environment variables, files on the filesystem, Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Defaults to 'default' if omitted.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - sshPrivateKey
+                    type: object
+                type: object
+              gitAuthSecret:
+                description: '(optional) GitAuthSecret is the the name of a secret containing an authentication option for the git repository. There are 3 different authentication options:   * Personal access token   * SSH private key (and it''s optional password)   * Basic auth username and password Only one authentication mode will be considered if more than one option is specified, with ssh private key/password preferred first, then personal access token, and finally basic auth credentials. Deprecated. Use GitAuth instead.'
+                type: string
+              projectRepo:
+                description: ProjectRepo is the git source control repository from which we fetch the project code and configuration.
+                type: string
+              refresh:
+                description: (optional) Refresh can be set to true to refresh the stack before it is updated.
+                type: boolean
+              repoDir:
+                description: (optional) RepoDir is the directory to work from in the project's source repository where Pulumi.yaml is located. It is used in case Pulumi.yaml is not in the project source root.
+                type: string
+              resyncFrequencySeconds:
+                description: (optional) ResyncFrequencySeconds when set to a non-zero value, triggers a resync of the stack at the specified frequency even if no changes to the custom-resource are detected. If branch tracking is enabled (branch is non-empty), commit polling will occur at this frequency. The minimal resync frequency supported is 60 seconds.
+                format: int64
+                type: integer
+              retryOnUpdateConflict:
+                description: (optional) RetryOnUpdateConflict issues a stack update retry reconciliation loop in the event that the update hits a HTTP 409 conflict due to another update in progress. This is only recommended if you are sure that the stack updates are idempotent, and if you are willing to accept retry loops until all spawned retries succeed. This will also create a more populated, and randomized activity timeline for the stack in the Pulumi Service.
+                type: boolean
+              secrets:
+                additionalProperties:
+                  type: string
+                description: '(optional) Secrets is the secret configuration for this stack, which can be optionally specified inline. If this is omitted, secrets configuration is assumed to be checked in and taken from the source repository. Deprecated: use SecretRefs instead.'
+                type: object
+              secretsProvider:
+                description: '(optional) SecretsProvider is used to initialize a Stack with alternative encryption. Examples:   - AWS:   "awskms:///arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34bc-56ef-1234567890ab?region=us-east-1"   - Azure: "azurekeyvault://acmecorpvault.vault.azure.net/keys/mykeyname"   - GCP:   "gcpkms://projects/MYPROJECT/locations/MYLOCATION/keyRings/MYKEYRING/cryptoKeys/MYKEY"   - See: https://www.pulumi.com/docs/intro/concepts/secrets/#initializing-a-stack-with-alternative-encryption'
+                type: string
+              secretsRef:
+                additionalProperties:
+                  description: ResourceRef identifies a resource from which information can be loaded. Environment variables, files on the filesystem, Kubernetes secrets and literal strings are currently supported.
+                  properties:
+                    env:
+                      description: Env selects an environment variable set on the operator process
+                      properties:
+                        name:
+                          description: Name of the environment variable
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    filesystem:
+                      description: FileSystem selects a file on the operator's file system
+                      properties:
+                        path:
+                          description: Path on the filesystem to use to load information from.
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    literal:
+                      description: LiteralRef refers to a literal value
+                      properties:
+                        value:
+                          description: Value to load
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    secret:
+                      description: SecretRef refers to a Kubernetes secret
+                      properties:
+                        key:
+                          description: Key within the secret to use.
+                          type: string
+                        name:
+                          description: Name of the secret
+                          type: string
+                        namespace:
+                          description: Namespace where the secret is stored. Defaults to 'default' if omitted.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type:
+                      description: 'SelectorType is required and signifies the type of selector. Must be one of: Env, FS, Secret, Literal'
+                      type: string
+                  required:
+                  - type
+                  type: object
+                description: (optional) SecretRefs is the secret configuration for this stack which can be specified through ResourceRef. If this is omitted, secrets configuration is assumed to be checked in and taken from the source repository.
+                type: object
+              stack:
+                description: Stack is the fully qualified name of the stack to deploy (<org>/<stack>).
+                type: string
+              useLocalStackOnly:
+                description: (optional) UseLocalStackOnly can be set to true to prevent the operator from creating stacks that do not exist in the tracking git repo. The default behavior is to create a stack if it doesn't exist.
+                type: boolean
+            required:
+            - projectRepo
+            - stack
+            type: object
+          status:
+            description: StackStatus defines the observed state of Stack
+            properties:
+              lastUpdate:
+                description: LastUpdate contains details of the status of the last update.
+                properties:
+                  lastAttemptedCommit:
+                    description: Last commit attempted
+                    type: string
+                  lastResyncTime:
+                    description: LastResyncTime contains a timestamp for the last time a resync of the stack took place.
+                    format: date-time
+                    type: string
+                  lastSuccessfulCommit:
+                    description: Last commit successfully applied
+                    type: string
+                  permalink:
+                    description: Permalink is the Pulumi Console URL of the stack operation.
+                    type: string
+                  state:
+                    description: State is the state of the stack update - one of `succeeded` or `failed`
+                    type: string
+                type: object
+              outputs:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: Outputs contains the exported stack output variables resulting from a deployment.
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/deploy/chart/templates/_helpers.tpl
+++ b/deploy/chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chart.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chart.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chart.labels" -}}
+helm.sh/chart: {{ include "chart.chart" . }}
+{{ include "chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chart.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "chart.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chart.fullname" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  # Currently only 1 replica supported, until leader election: https://github.com/pulumi/pulumi-kubernetes-operator/issues/33
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "chart.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: tmp-dir
+          emptyDir: {}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- if .Values.extraArgs }}
+          args:
+            {{- toYaml .Values.extraArgs | nindent 12}}
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-dir
+          env:
+            {{- toYaml .Values.extraEnv | nindent 12 }}
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/chart/templates/rbac.yaml
+++ b/deploy/chart/templates/rbac.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pulumi-kubernetes-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - pulumi-kubernetes-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - pulumi.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pulumi-kubernetes-operator
+subjects:
+- kind: ServiceAccount
+  name: pulumi-kubernetes-operator
+roleRef:
+  kind: Role
+  name: pulumi-kubernetes-operator
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/deploy/chart/templates/secret.yaml
+++ b/deploy/chart/templates/secret.yaml
@@ -1,0 +1,8 @@
+{{ if and .Values.pulumiTokenSecret.create .Values.pulumiTokenSecret.token }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Values.pulumiTokenSecret.secretName }}"
+stringData:
+  "{{ .Values.pulumiTokenSecret.secretKey }}": "{{ .Values.pulumiTokenSecret.token }}"
+{{ end }}

--- a/deploy/chart/templates/serviceaccount.yaml
+++ b/deploy/chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "chart.serviceAccountName" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -33,6 +33,7 @@ extraEnv:
   - name: PULUMI_INFER_NAMESPACE
     value: "1"
 
+# Create operator RBAC
 rbac:
   create: true
 

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,0 +1,86 @@
+image:
+  repository: pulumi/pulumi-kubernetes-operator
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: latest
+
+imagePullSecrets: []
+
+# Create a Secret to store your Pulumi access token for use by Stack CRDs
+pulumiTokenSecret:
+  # Set this to true and provide a token to create the secret
+  create: false
+  # Raw Pulumi token value
+  token:
+  # Name of the Secret to be created
+  secretName: pulumi-access-token
+  # Key that will contain the token
+  secretKey: token
+
+# Additional command arguments to pass to the controller
+extraArgs:
+  - --zap-level=error
+  - --zap-time-encoding=iso8601
+
+# Additional environment variables to pass to the controller
+extraEnv:
+  - name: OPERATOR_NAME
+    value: "pulumi-kubernetes-operator"
+  - name: GRACEFUL_SHUTDOWN_TIMEOUT_DURATION
+    value: "5m"
+  - name: MAX_CONCURRENT_RECONCILES
+    value: "10"
+  - name: PULUMI_INFER_NAMESPACE
+    value: "1"
+
+rbac:
+  create: true
+
+terminationGracePeriodSeconds: 300
+
+nameOverride: ""
+
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
### Proposed changes
This PR adds a basic Helm chart to the `deploy` directory. 
It can be tested by provisioning a cluster and running `helm upgrade --install --wait pulumi-kubernetes-operator deploy/chart/`.

### Related issues (optional)
Closes #260