### PR TITLE
Add additional columns when getting resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-(None)
+- Add `State` to `additionalPrinterColumns`
 
 ## 1.5.0 (2022-03-14)
 - Use configured namespace for envRef Secrets, instead of defaulting to 'default'

--- a/deploy/crds/pulumi.com_stacks.yaml
+++ b/deploy/crds/pulumi.com_stacks.yaml
@@ -16,7 +16,14 @@ spec:
     singular: stack
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    - jsonPath: .status.lastUpdate.state
+      name: STATE
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: Stack is the Schema for the stacks API


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

To get a better visibility of the state of the stacks, I modified the crd to add additional columns.

```
-> kubectl get stack
NAME             AGE   STATE
s3-stack-error   43s   failed
```

Let me know if you have any comments/questions.

