### PR TITLE
Pick a single, watched namespace for leader lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-(None)
+- Use the first namespace from the env entry WATCH_NAMESPACE for leadership election, when the value is a list; and bail if the value is malformed [#278](https://github.com/pulumi/pulumi-kubernetes-operator/pull/278)
 
 ## 1.6.0 (2022-04-21)
 - Add `State` to `additionalPrinterColumns`


### PR DESCRIPTION
### Proposed changes

At present when the environment variable `WATCH_NAMESPACE` is given, it is used verbatim as the namespace for the leadership election module; but, the value can be a comma-delimited list, e.g., `foo,bar`, which are not valid namespace names.

This commit fixes that by ensuring a single namespace name is used. Any of the watched namespaced would do, on the assumption that no other deployment of this operator will be using those namespaces.

### Related issues (optional)

Fixes #273.

### TODO

 - ~[ ] Unit tests (needs scaffolding, first)~ (EDIT: deprecated in favour of _actually trying it_)