### PR TITLE
Guard deref of pointer field .Status.LastUpdate

### DIFF
--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -272,7 +272,7 @@ func (r *ReconcileStack) Reconcile(ctx context.Context, request reconcile.Reques
 		}
 	}
 
-	if trackBranch {
+	if trackBranch && instance.Status.LastUpdate != nil {
 		reqLogger.Info("Checking current HEAD commit hash", "Current commit", currentCommit)
 		if instance.Status.LastUpdate.LastSuccessfulCommit == currentCommit && !sess.stack.ContinueResyncOnCommitMatch {
 			reqLogger.Info("Commit hash unchanged. Will poll again.", "pollFrequencySeconds", resyncFreqSeconds)

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -390,6 +390,9 @@ func (r *ReconcileStack) markStackFailed(sess *reconcileStackSession, instance *
 	r.emitEvent(instance, pulumiv1.StackUpdateFailureEvent(), "Failed to update Stack: %v.", err.Error())
 	sess.logger.Error(err, "Failed to update Stack", "Stack.Name", sess.stack.Stack)
 	// Update Stack status with failed state
+	if instance.Status.LastUpdate == nil {
+		instance.Status.LastUpdate = &shared.StackUpdateState{}
+	}
 	instance.Status.LastUpdate.LastAttemptedCommit = currentCommit
 	instance.Status.LastUpdate.State = shared.FailedStackStateMessage
 	instance.Status.LastUpdate.Permalink = permalink


### PR DESCRIPTION
In a new resource, the status will be the zero value, meaning pointer-valued fields will be nil. The controller dereferences the field `.Status.LastUpdate` without first checking whether it's nil, leading to a nil pointer dereference.

The quick solution in this case is to skip the offending block if the field is nil. This avoids the nil pointer dereference; and it's correct because the code within the block is irrelevant if there's no last update.
