### PR TITLE
Remove trace and rebuild-all for static build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,7 +15,7 @@ extra_args=""
 if [ "$build_static" == "static" ]; then
 	export CGO_ENABLED=0
 	ldflags="$ldflags -w -extldflags \"-static\""
-	extra_args="-x -a -tags netgo"
+	extra_args="-tags netgo"
 fi
 
 # Build the operator.


### PR DESCRIPTION
The extra-verbose output (`-x`) from the static build (e.g., when doing `make build-image`) is rarely useful. Similarly, there's no reason to rebuild everything (`-a`) every time. It used to be necessary, or at least safe, to rebuild everything with `-netgo`, but happily those days are over.
