### PR TITLE
update stacks_failing metric to check pulumiv1.Stack instead of pulumiv1alpha1.Stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 - CI update to go 1.18
 - Bump to v3.36.0 of Pulumi, to support short branch names in .spec.branch after
   [pulumi/pulumi#10118](https://github.com/pulumi/pulumi/pull/10118)
+- Fix `stacks_failing` prometheus metric for `Stack`s with apiVersion `v1`
 
 ## 1.7.0 (2022-06-09)
 - Use the first namespace from the env entry WATCH_NAMESPACE for leadership election, when the value is a list; and bail if the value is malformed [#278](https://github.com/pulumi/pulumi-kubernetes-operator/pull/278)

--- a/pkg/controller/stack/metrics.go
+++ b/pkg/controller/stack/metrics.go
@@ -5,7 +5,7 @@ package stack
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/pulumi/pulumi-kubernetes-operator/pkg/apis/pulumi/shared"
-	pulumiv1alpha1 "github.com/pulumi/pulumi-kubernetes-operator/pkg/apis/pulumi/v1alpha1"
+	pulumiv1 "github.com/pulumi/pulumi-kubernetes-operator/pkg/apis/pulumi/v1"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -43,12 +43,12 @@ func newStackCallback(obj interface{}) {
 }
 
 func updateStackCallback(oldObj, newObj interface{}) {
-	oldStack, ok := oldObj.(*pulumiv1alpha1.Stack)
+	oldStack, ok := oldObj.(*pulumiv1.Stack)
 	if !ok {
 		return
 	}
 
-	newStack, ok := newObj.(*pulumiv1alpha1.Stack)
+	newStack, ok := newObj.(*pulumiv1.Stack)
 	if !ok {
 		return
 	}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Update `stacks_failing` metric to use the current `v1` Stack API version instead of the outdated `v1alpha1`.

From my observations, the pulumi-k8s-operator automatically upgrades new applications of the `Stack` resources to `v1` if they are applied with the older API version, so for new `Stack`s it should be fine that this PR does not account for the old API version. However, I don't know if the operator converts old `Stack` resources to the new version so whether not this is a breaking change is not known to me right now.

### Related issues (optional)

https://github.com/pulumi/pulumi-kubernetes-operator/issues/307

### Additional comments

I tested this locally, but I tested it with a base branch from the 1.7.0 release commit https://github.com/pulumi/pulumi-kubernetes-operator/commit/cb9f70c3bd1e983daa5fd9b2926ed386af56d4e0 instead of the latest `master` branch because the pulumi-k8s-operator was giving me errors when attempting to checkout the git branch: `unable to checkout branch: reference not found`

Somehow the change in https://github.com/pulumi/pulumi-kubernetes-operator/commit/ef96c6d7cd4aeeb185e757f0f5dcac445ef62c53 (specifically the change in https://github.com/pulumi/pulumi/pull/10118) did not work for me for both branch formats: `refs/remotes/origin/foo` and `foo`.