### PR TITLE
Clear up the deletion and finalization protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-(None)
+
+- Exit processing early when a stack is ready to be garbage collected
+  [#322](https://github.com/pulumi/pulumi-kubernetes-operator/pull/322)
 
 ## 1.8.0 (2022-09-01)
 - Use go 1.18 for builds


### PR DESCRIPTION
The controller departs from the usual scheme of adding a finalizer, and exiting early, at the top of the Reconcile func. This PR documents why, and adds some early exits where possible.

In addition: the code that handles finalization (cleaning up when a Stack has been deleted) removes the finalizer record, saves the object, then waits for the Kubernetes API server to delete the object. The rationale is that waiting until the cache has caught up means the reconciler "knows" it has been deleted. Waiting for the deletion to be seen by the client is not necessary, though -- even if the controller sees the object again, once the finalizer has been removed it will exit without processing it.
