### PR TITLE
Parallelise and randomize tests

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -44,6 +44,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.19.x
+      - name: Install Ginkgo testing framework
+        run: |
+          # Do the install from outside the code tree to avoid messing with go.sum
+          cd /tmp; go install github.com/onsi/ginkgo/ginkgo@v1.16.4
       - name: Configure AWS credentials to use in AWS Stack tests
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: "1.19.x"
+      - name: Install Ginkgo testing framework
+        run: |
+          # Do the install from outside the code tree to avoid messing with go.sum
+          cd /tmp; go install github.com/onsi/ginkgo/ginkgo@v1.16.4
       - name: Configure AWS credentials to use in AWS Stack tests
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/run-acceptance-tests.yaml
+++ b/.github/workflows/run-acceptance-tests.yaml
@@ -56,6 +56,10 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.19.x
+      - name: Install Ginkgo testing framework
+        run: |
+          # Do the install from outside the code tree to avoid messing with go.sum
+          cd /tmp; go install github.com/onsi/ginkgo/ginkgo@v1.16.4
       - name: Configure AWS credentials to use in AWS Stack tests
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ push-image:
 	docker push $(IMAGE_NAME):$(VERSION)
 
 test: codegen download-test-deps
-	KUBEBUILDER_ASSETS="$(shell setup-envtest --use-env use -p path)" go test -v ./test/...
+	KUBEBUILDER_ASSETS="$(shell setup-envtest --use-env use -p path)" \
+		ginkgo -nodes=4 --randomizeAllSpecs ./test/...
 
 deploy:
 	kubectl apply -f deploy/yaml/service_account.yaml

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -86,7 +86,7 @@ var _ = BeforeSuite(func() {
 	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:                 scheme.Scheme,
 		HealthProbeBindAddress: "0",
-		MetricsBindAddress:     "0.0.0.0:8383",
+		MetricsBindAddress:     "0",
 	})
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Many of the tests take O(1m) to run, and the more specs added the longer the runtime. Parallelising the tests will help defer the day we need to increase the overall timeout.

Randomising helps keep the tests independent, by surfacing things that work by coincidence.

Enabling either of these requires the use of the Ginkgo command line -- it's not possible to enable them programmatically. So: reinstate the use of `ginkgo` for running tests.

(Empirically, I found that using `ginkgo -p` would result in timeouts waiting for the control plane to start. `-nodes=4` seems like a reasonable compromise.)