### PR TITLE
Example of deploying the operator with Flux source controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ CHANGELOG
 
 - Make .ContinueResyncOnCommitMatch apply to all sources (git, Flux sources, or Program objects)
   [#346](https://github.com/pulumi/pulumi-kubernetes-operator/pull/346)
+- Give an example of using this operator with a Flux GitRepository and webhooks, in
+  `examples/flux-source`.
+  [#339](https://github.com/pulumi/pulumi-kubernetes-operator/pull/339)
 
 ## 1.10.0-rc.1 (2022-10-18) (release candidate)
 

--- a/examples/flux-source/Pulumi.yaml
+++ b/examples/flux-source/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: flux-and-pulumi
+runtime: nodejs
+description: Deploy Pulumi and Flux together

--- a/examples/flux-source/README.md
+++ b/examples/flux-source/README.md
@@ -52,7 +52,7 @@ app$ pulumi up
 This creates a `GitRepository` object in the cluster, which you can examine:
 
 ```console
-kubectl get gitrepository
+app$ kubectl get gitrepository
 ```
 
 and a `Stack` object, pointing at the `GitRepository` object, which will run the program and create

--- a/examples/flux-source/README.md
+++ b/examples/flux-source/README.md
@@ -45,6 +45,7 @@ To run the program:
 
 ```console
 app$ pulumi config set git-url https://github.com/squaremo/pko-dev
+app$ pulumi config set stack-name $(pulumi whoami)/app/dev
 app$ pulumi up
 ```
 

--- a/examples/flux-source/README.md
+++ b/examples/flux-source/README.md
@@ -1,0 +1,98 @@
+# Example of using the Pulumi Kubernetes operator with Flux
+
+The Pulumi operator can use [Flux sources][] for getting Pulumi programs. This example shows how to
+set the operator, and Flux source controller, up; and, how to create a `GitRepository` (a Flux
+source) and a `Stack` object that points to it.
+
+## Running the installation program
+
+The project in this directory will:
+
+ - install the Flux source CRDs and controller
+ - install the Pulumi operator and its CRD(s)
+ - give the Pulumi operator permissions to see Flux source objects
+
+You'll need to install the program dependencies:
+
+```console
+flux-source$ npm install
+```
+
+Now you can run the stack with the Pulumi command-line:
+
+```console
+flux-source$ pulumi up
+```
+
+## Running the example app Stack
+
+You will need to install the dependencies for the program:
+
+```console
+app$ npm install
+```
+
+For the project in `app/`, you'll need a Pulumi access token. You can create one in the [Pulumi
+service][] under "Access tokens". Assign it to the environment variable
+`PULUMI_ACCESS_TOKEN`.
+
+To run the program:
+
+```console
+app$ pulumi up
+```
+
+This creates a `GitRepository` object in the cluster, which you can examine:
+
+```console
+kubectl get gitrepository
+```
+
+and a `Stack` object, pointing at the `GitRepository` object, which will run the program and create
+a deployment. You watch the stack object until it has completed:
+
+```console
+app$ kubectl get stack -w
+```
+
+You should see the state become `succeeded` in a minute or so. The result of the stack is a
+deployment:
+
+```console
+app$ kubectl get deployment
+```
+
+You can also look in the [Pulumi service][] to see what it creates.
+
+## Installing development versions
+
+You can use the install program to run a locally-built image, with the following steps.
+
+ * install the CRD over the top of that installed by the stack
+
+```console
+pulumi-kubernetes-operator$ make install-crds
+```
+
+ * build a development version of the image:
+
+```console
+pulumi-kubernetes-operator$ make build-image IMAGE_NAME=pulumi/pulumi-kubernetes-operator
+```
+
+(`IMAGE_NAME` means it won't name the image after `$(whoami)`)
+
+> If you're using `kind` to run a local Kubernetes cluster, you will need to side-load the image:
+>
+> ```console
+> kind load docker-image pulumi/pulumi-kubernetes-operator:$(git rev-parse --short HEAD)
+> ```
+
+ * use that image's tag as the `operator-version` configuration item when running the stack:
+
+```console
+pulumi-kubernetes-operator/examples/flux-source$ pulumi up -c operator-version=$(git rev-parse --short HEAD)
+```
+
+[Flux source]: https://fluxcd.io/flux/components/source/api/
+[Pulumi service]: https://app.pulumi.com/

--- a/examples/flux-source/README.md
+++ b/examples/flux-source/README.md
@@ -36,9 +36,15 @@ For the project in `app/`, you'll need a Pulumi access token. You can create one
 service][] under "Access tokens". Assign it to the environment variable
 `PULUMI_ACCESS_TOKEN`.
 
+You will also need to supply a git repository URL. You can use my example:
+`https://github.com/squaremo/pko-dev`, but you won't be able to install webhooks there, so it might
+pay to fork that or create your own. (If you do create your own, you will likely want to change the
+`dir` in the Stack spec, which gives the subdirectory of the repo where your Pulumi code is).
+
 To run the program:
 
 ```console
+app$ pulumi config set git-url https://github.com/squaremo/pko-dev
 app$ pulumi up
 ```
 
@@ -63,6 +69,37 @@ app$ kubectl get deployment
 ```
 
 You can also look in the [Pulumi service][] to see what it creates.
+
+## Webhooks
+
+The program in `app/` also creates a webhook receiver, so you can get notifications from GitHub when
+there are new commits pushed. You will need to expose the webhook service to the internet for this
+to work: either use the guide in
+https://fluxcd.io/flux/guides/webhook-receivers/#expose-the-webhook-receiver, or use something like
+ngrok to tunnel the webhook into a private cluster. If you use the Flux guide, be aware that the
+webhook receiver here is in `default` namespace, rather than `flux-system`. There's a working
+example for ngrok in `ngrok/`.
+
+### Using ngrok to tunnel webhooks
+
+The directory `ngrok/` has a program that will run ngrok in such a way as to make the webhooks
+work. It doesn't need any configuration; just:
+
+```console
+ngrok$ pulumi up
+```
+
+To see the public hostname that it's set up, access the ngrok console:
+
+```console
+ngrok$ NGROK_SERVICE=$(pulumi stack output service)
+ngrok$ kubectl port-forward service/$NGROK_SERVICE 4040:80
+```
+
+The ngrok console will then be reachable on http://localhost:4040/.
+
+Bear in mind that the tunnel hostname will change every time this restarts, so it's only really
+useful for (shortlived) demos.
 
 ## Installing development versions
 

--- a/examples/flux-source/app/.gitignore
+++ b/examples/flux-source/app/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/examples/flux-source/app/Pulumi.dev.yaml
+++ b/examples/flux-source/app/Pulumi.dev.yaml
@@ -1,0 +1,2 @@
+config:
+  app:git-url: https://github.com/squaremo/pko-dev

--- a/examples/flux-source/app/Pulumi.yaml
+++ b/examples/flux-source/app/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: app
+description: Application stack for Flux+Pulumi
+runtime: nodejs

--- a/examples/flux-source/app/index.ts
+++ b/examples/flux-source/app/index.ts
@@ -1,0 +1,51 @@
+import * as k8s from "@pulumi/kubernetes";
+
+
+// A git repository source for our Pulumi program
+const gitRepo = new k8s.apiextensions.CustomResource("pko-dev", {
+    apiVersion: 'source.toolkit.fluxcd.io/v1beta2',
+    kind: 'GitRepository',
+    metadata: {
+        'namespace': 'default',
+    },
+    spec: {
+        interval: '5m0s',
+        url: 'https://github.com/squaremo/pko-dev',
+        ref: { branch: 'main' },
+    },
+});
+
+// A secret with the Pulumi access token, taken from the environment.
+const tokenSecret = new k8s.core.v1.Secret("pulumi-token", {
+    stringData: {
+        'PULUMI_ACCESS_TOKEN': process.env['PULUMI_ACCESS_TOKEN'] || 'token',
+    },
+});
+
+const stack = new k8s.apiextensions.CustomResource("basic", {
+    apiVersion: 'pulumi.com/v1',
+    kind: 'Stack',
+    metadata: {
+        'namespace': 'default',
+    },
+    spec: {
+        stack: 'squaremo/basic/docker-desktop',
+        envRefs: {
+            'PULUMI_ACCESS_TOKEN': {
+                'type': 'Secret',
+                'secret': {
+                    key: 'PULUMI_ACCESS_TOKEN',
+                    name: tokenSecret.metadata.name,
+                },
+            },
+        },
+        fluxSource: {
+            sourceRef: {
+                apiVersion: gitRepo.apiVersion,
+                kind: gitRepo.kind,
+                name: gitRepo.metadata.name,
+            },
+            dir: 'basic',
+        },
+    },
+});

--- a/examples/flux-source/app/index.ts
+++ b/examples/flux-source/app/index.ts
@@ -18,10 +18,15 @@ const gitRepo = new k8s.apiextensions.CustomResource("pko-dev", {
     },
 });
 
+const pulumiToken = process.env['PULUMI_ACCESS_TOKEN'];
+if (!pulumiToken) {
+    throw new Error('This stack needs a Pulumi access token in the environment variable PULUMI_ACCESS_TOKEN')
+}
+
 // A secret with the Pulumi access token, taken from the environment.
 const tokenSecret = new k8s.core.v1.Secret("pulumi-token", {
     stringData: {
-        'PULUMI_ACCESS_TOKEN': process.env['PULUMI_ACCESS_TOKEN'] || 'token',
+        'PULUMI_ACCESS_TOKEN': pulumiToken,
     },
 });
 

--- a/examples/flux-source/app/index.ts
+++ b/examples/flux-source/app/index.ts
@@ -2,7 +2,9 @@ import * as pulumi from "@pulumi/pulumi";
 import * as k8s from "@pulumi/kubernetes";
 import * as random from "@pulumi/random";
 
-export const gitURL = new pulumi.Config().require('git-url');
+const config = new pulumi.Config();
+export const gitURL = config.require('git-url');
+export const stackName = config.require('stack-name');
 
 // A git repository source for our Pulumi program
 const gitRepo = new k8s.apiextensions.CustomResource("pko-dev", {
@@ -37,7 +39,7 @@ const stack = new k8s.apiextensions.CustomResource("basic", {
         'namespace': 'default',
     },
     spec: {
-        stack: 'squaremo/basic/docker-desktop',
+        stack: stackName,
         envRefs: {
             'PULUMI_ACCESS_TOKEN': {
                 'type': 'Secret',

--- a/examples/flux-source/app/package.json
+++ b/examples/flux-source/app/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "app",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^14"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/kubernetes": "^3.0.0",
+        "@pulumi/kubernetesx": "^0.1.5"
+    }
+}

--- a/examples/flux-source/app/package.json
+++ b/examples/flux-source/app/package.json
@@ -5,8 +5,9 @@
         "@types/node": "^14"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^3.0.0",
         "@pulumi/kubernetes": "^3.0.0",
-        "@pulumi/kubernetesx": "^0.1.5"
+        "@pulumi/kubernetesx": "^0.1.5",
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/random": "^4.8.2"
     }
 }

--- a/examples/flux-source/app/tsconfig.json
+++ b/examples/flux-source/app/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/examples/flux-source/index.ts
+++ b/examples/flux-source/index.ts
@@ -1,0 +1,250 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as kubernetes from "@pulumi/kubernetes";
+import { ConfigGroup } from "@pulumi/kubernetes/yaml";
+import * as flux from "@worawat/flux";
+
+const config = new pulumi.Config();
+const deployNamespace = config.get("namespace") || 'default';
+const deployNamespaceList = config.getObject<string[]>("namespaces") || [deployNamespace];
+const excludeCrds = config.getBoolean("exclude-crds");
+const operatorVersion = config.get("operator-version") || "v1.9.0";
+
+// -- Flux installation
+
+const fluxManifests = flux.getFluxInstallOutput({
+    targetPath: "local",
+    components: ['source-controller'],
+    networkPolicy: true,
+});
+
+// this effectively installs the Flux controllers
+const fluxGroup = fluxManifests.content.apply(c => new ConfigGroup("flux-install", { yaml: c }));
+
+// --- Pulumi operator
+
+let deploymentOptions = {};
+
+if (!excludeCrds) {
+    const crds = new kubernetes.yaml.ConfigFile("crds", {file: `https://raw.githubusercontent.com/pulumi/pulumi-kubernetes-operator/${operatorVersion}/deploy/crds/pulumi.com_stacks.yaml`});
+    deploymentOptions = { dependsOn: crds };
+}
+
+for (let ns of deployNamespaceList) {
+    const operatorServiceAccount = new kubernetes.core.v1.ServiceAccount(`operator-service-account-${ns}`, {
+        metadata: {
+            "namespace": ns,
+        },
+    });
+
+    const operatorRole = new kubernetes.rbac.v1.Role(`operator-role-${ns}`, {
+        metadata: {
+            "namespace": ns,
+        },
+        rules: [
+            {
+                apiGroups: [""],
+                resources: [
+                    "pods",
+                    "services",
+                    "services/finalizers",
+                    "endpoints",
+                    "persistentvolumeclaims",
+                    "events",
+                    "configmaps",
+                    "secrets",
+                ],
+                verbs: [
+                    "create",
+                    "delete",
+                    "get",
+                    "list",
+                    "patch",
+                    "update",
+                    "watch",
+                ],
+            },
+            {
+                apiGroups: ["apps"],
+                resources: [
+                    "deployments",
+                    "daemonsets",
+                    "replicasets",
+                    "statefulsets",
+                ],
+                verbs: [
+                    "create",
+                    "delete",
+                    "get",
+                    "list",
+                    "patch",
+                    "update",
+                    "watch",
+                ],
+            },
+            {
+                apiGroups: ["monitoring.coreos.com"],
+                resources: ["servicemonitors"],
+                verbs: [
+                    "create",
+                    "get",
+                ],
+            },
+            {
+                apiGroups: ["apps"],
+                resourceNames: ["pulumi-kubernetes-operator"],
+                resources: ["deployments/finalizers"],
+                verbs: ["update"],
+            },
+            {
+                apiGroups: [""],
+                resources: ["pods"],
+                verbs: ["get"],
+            },
+            {
+                apiGroups: ["apps"],
+                resources: [
+                    "replicasets",
+                    "deployments",
+                ],
+                verbs: ["get"],
+            },
+            {
+                apiGroups: ["pulumi.com"],
+                resources: ["*"],
+                verbs: [
+                    "create",
+                    "delete",
+                    "get",
+                    "list",
+                    "patch",
+                    "update",
+                    "watch",
+                ],
+            },
+
+            {
+                apiGroups: ["coordination.k8s.io"],
+                resources: ["leases"],
+                verbs: [
+                    "create",
+                    "get",
+                    "list",
+                    "update",
+                ],
+            },
+        ],
+    });
+
+    const fluxAccessRole = new kubernetes.rbac.v1.Role(`flux-role-${ns}`, {
+        metadata: {
+            "namespace": ns,
+        },
+        rules: [
+            // this is specifically to give access to Flux sources
+            {
+                apiGroups: ["source.toolkit.fluxcd.io"],
+                resources: ["*"],
+                verbs: [
+                    "get",
+                    "list",
+                    "watch",
+                ],
+            },
+        ],
+    });
+    
+    const operatorRoleBinding = new kubernetes.rbac.v1.RoleBinding(`operator-role-binding-${ns}`, {
+        metadata: {
+            "namespace": ns,
+        },
+        subjects: [{
+            kind: "ServiceAccount",
+            name: operatorServiceAccount.metadata.name,
+        }],
+        roleRef: {
+            kind: "Role",
+            name: operatorRole.metadata.name,
+            apiGroup: "rbac.authorization.k8s.io",
+        },
+    });
+
+    const fluxRoleBinding = new kubernetes.rbac.v1.RoleBinding(`flux-role-binding-${ns}`, {
+        metadata: {
+            "namespace": ns,
+        },
+        subjects: [{
+            kind: "ServiceAccount",
+            name: operatorServiceAccount.metadata.name,
+        }],
+        roleRef: {
+            kind: "Role",
+            name: fluxAccessRole.metadata.name,
+            apiGroup: "rbac.authorization.k8s.io",
+        },
+    });
+
+    const operatorDeployment = new kubernetes.apps.v1.Deployment(`pulumi-kubernetes-operator-${ns}`, {
+        metadata: {
+            "namespace": ns,
+        },
+        spec: {
+            replicas: 1,
+            selector: {
+                matchLabels: {
+                    name: "pulumi-kubernetes-operator",
+                },
+            },
+            template: {
+                metadata: {
+                    labels: {
+                        name: "pulumi-kubernetes-operator",
+                    },
+                },
+                spec: {
+                    serviceAccountName: operatorServiceAccount.metadata.name,
+                    containers: [{
+                        name: "pulumi-kubernetes-operator",
+                        image: `pulumi/pulumi-kubernetes-operator:${operatorVersion}`,
+                        imagePullPolicy: "IfNotPresent",
+                        args: ["--zap-level=error", "--zap-time-encoding=iso8601"],
+                        env: [
+                            {
+                                name: "WATCH_NAMESPACE",
+                                valueFrom: {
+                                    fieldRef: {
+                                        fieldPath: "metadata.namespace",
+                                    },
+                                },
+                            },
+                            {
+                                name: "POD_NAME",
+                                valueFrom: {
+                                    fieldRef: {
+                                        fieldPath: "metadata.name",
+                                    },
+                                },
+                            },
+                            {
+                                name: "OPERATOR_NAME",
+                                value: "pulumi-kubernetes-operator",
+                            },
+                            {
+                                name: "GRACEFUL_SHUTDOWN_TIMEOUT_DURATION",
+                                value: "5m",
+                            },
+                            {
+                                name: "MAX_CONCURRENT_RECONCILES",
+                                value: "10",
+                            },
+
+
+                        ],
+                    }],
+                    // Should be same or larger than GRACEFUL_SHUTDOWN_TIMEOUT_DURATION
+                    terminationGracePeriodSeconds: 300,
+                },
+            },
+        },
+    }, deploymentOptions);
+}
+

--- a/examples/flux-source/index.ts
+++ b/examples/flux-source/index.ts
@@ -7,6 +7,7 @@ const config = new pulumi.Config();
 const deployNamespace = config.get("namespace") || 'default';
 const deployNamespaceList = config.getObject<string[]>("namespaces") || [deployNamespace];
 const operatorVersion = config.get("operator-version") || "v1.9.0";
+const crdVersion = config.get("crd-version") || "v1.9.0";
 
 // -- Flux installation
 
@@ -21,7 +22,9 @@ const fluxGroup = fluxManifests.content.apply(c => new ConfigGroup("flux-install
 
 // --- Pulumi operator
 
-const crd = kubernetes.apiextensions.v1.CustomResourceDefinition.get('stacks-crd', 'stacks.pulumi.com');
+const crd = new kubernetes.yaml.ConfigFile('stack-crd', {
+    file: `https://raw.githubusercontent.com/pulumi/pulumi-kubernetes-operator/${crdVersion}/deploy/crds/pulumi.com_stacks.yaml`,
+});
 const deploymentOptions = { dependsOn: crd };
 
 for (let ns of deployNamespaceList) {

--- a/examples/flux-source/index.ts
+++ b/examples/flux-source/index.ts
@@ -6,8 +6,8 @@ import * as flux from "@worawat/flux";
 const config = new pulumi.Config();
 const deployNamespace = config.get("namespace") || 'default';
 const deployNamespaceList = config.getObject<string[]>("namespaces") || [deployNamespace];
-const operatorVersion = config.get("operator-version") || "v1.9.0";
-const crdVersion = config.get("crd-version") || "v1.9.0";
+const operatorVersion = config.get("operator-version") || "v1.10.0";
+const crdVersion = config.get("crd-version") || "v1.10.0";
 
 // -- Flux installation
 

--- a/examples/flux-source/ngrok/Pulumi.yaml
+++ b/examples/flux-source/ngrok/Pulumi.yaml
@@ -1,0 +1,39 @@
+name: ngrok
+runtime: yaml
+description: Run ngrok to tunnel webhooks to Flux
+
+variables:
+  appLabels:
+    app: ngrok
+
+resources:
+  deployment:
+    type: kubernetes:apps/v1:Deployment
+    properties:
+      spec:
+        selector:
+          matchLabels: ${appLabels}
+        replicas: 1
+        template:
+          metadata:
+            labels: ${appLabels}
+          spec:
+            containers:
+              - name: ngrok
+                image: ngrok/ngrok:2.3.40-alpine
+                args:
+                  - http
+                  - webhook-receiver.flux-system:80
+
+  service:
+    type: kubernetes:core/v1:Service
+    properties:
+      spec:
+        selector: ${appLabels}
+        ports:
+          - port: 80
+            targetPort: 4040
+
+outputs:
+  deployment: ${deployment.metadata.name}
+  service: ${service.metadata.name}

--- a/examples/flux-source/package.json
+++ b/examples/flux-source/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "deploy-operator-ts",
+    "devDependencies": {
+        "@types/node": "^14"
+    },
+    "dependencies": {
+        "@pulumi/kubernetes": "^3.0.0",
+        "@pulumi/kubernetesx": "^0.1.5",
+        "@pulumi/pulumi": "^3.0.0",
+        "@worawat/flux": "^1.0.0"
+    }
+}

--- a/examples/flux-source/tsconfig.json
+++ b/examples/flux-source/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
This example shows how to set up the operator and Flux's source controller so they can work together. It includes a subordinate example which shows how to create a `GitRepository` (a Flux source) and a `Stack` object that points to it.

This should remain a draft until the Flux support is released.