### PR TITLE
Make mutual exclusion of sources obvious

### DIFF
--- a/test/invalid_spec_test.go
+++ b/test/invalid_spec_test.go
@@ -71,8 +71,8 @@ var _ = Describe("Stacks that should stall because of an invalid spec", func() {
 		}
 	})
 
-	checkInvalidSpecStalls("more than one source is given", func(s *pulumiv1.Stack) {
-		s.Name = "more-than-one-source"
+	checkInvalidSpecStalls("git and flux sources are both given", func(s *pulumiv1.Stack) {
+		s.Name = "git-and-flux-source"
 		s.Spec.GitSource = &shared.GitSource{
 			ProjectRepo: "https://github.com/pulumi/pulumi-kubernetes-operator",
 			Branch:      "default",
@@ -83,4 +83,28 @@ var _ = Describe("Stacks that should stall because of an invalid spec", func() {
 			},
 		}
 	})
+
+	checkInvalidSpecStalls("git and program sources are both given", func(s *pulumiv1.Stack) {
+		s.Name = "git-and-program-source"
+		s.Spec.GitSource = &shared.GitSource{
+			ProjectRepo: "https://github.com/pulumi/pulumi-kubernetes-operator",
+			Branch:      "default",
+		}
+		s.Spec.ProgramRef = &shared.ProgramReference{
+			Name: "foo",
+		}
+	})
+
+	checkInvalidSpecStalls("flux and program sources are both given", func(s *pulumiv1.Stack) {
+		s.Name = "flux-and-program-source"
+		s.Spec.FluxSource = &shared.FluxSource{
+			SourceRef: shared.FluxSourceReference{
+				Name: "foo",
+			},
+		}
+		s.Spec.ProgramRef = &shared.ProgramReference{
+			Name: "foo",
+		}
+	})
+
 })


### PR DESCRIPTION
This changes the which-source-is-it switch around a little, so that instead of each case checking something is non-nil and all the others are nil, the invalid cases are ruled out first. This makes it a little easier to extend, since you only have to update the constraint check, then add your case in.

Logical check for invalidity:

```go
(gitPresent == fluxPresent && fluxPresent == programPresent) ||  // i.e., all true or all false
		(gitPresent && fluxPresent) ||                   // ) or, any two are true
		(fluxPresent && programPresent) ||               // ) ...
		(gitPresent && programPresent)                   // ) ...
```

This is a bit unwieldy with three cases, and would be unmanageable with four or more; so I wrote this iterative check:

```go
exactlyOneOf := func(these ...bool) bool {
	var found bool
	for _, b := range these {
		if found && b {
			return false
		}
		found = found || b
	}
	return found
}
```
