### PR TITLE
Let ContinueResyncOnCommitMatch apply to all sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Make .ContinueResyncOnCommitMatch apply to all sources (git, Flux sources, or Program objects)
+  [#346](https://github.com/pulumi/pulumi-kubernetes-operator/pull/346)
+
 ## 1.10.0-rc.1 (release candidate)
 
 - Make `.spec.projectRepo` optional in the Stack CRD. This is technically a breaking change

--- a/deploy/crds/pulumi.com_stacks.yaml
+++ b/deploy/crds/pulumi.com_stacks.yaml
@@ -83,11 +83,12 @@ spec:
               continueResyncOnCommitMatch:
                 description: (optional) ContinueResyncOnCommitMatch - when true -
                   informs the operator to continue trying to update stacks even if
-                  the commit matches. This might be useful in environments where Pulumi
-                  programs have dynamic elements for example, calls to internal APIs
-                  where GitOps style commit tracking is not sufficient. Defaults to
-                  false, i.e. when a particular commit is successfully run, the operator
-                  will not attempt to rerun the program at that commit again.
+                  the revision of the source matches. This might be useful in environments
+                  where Pulumi programs have dynamic elements for example, calls to
+                  internal APIs where GitOps style commit tracking is not sufficient.  Defaults
+                  to false, i.e. when a particular revision is successfully run, the
+                  operator will not attempt to rerun the program at that revision
+                  again.
                 type: boolean
               destroyOnFinalize:
                 description: (optional) DestroyOnFinalize can be set to true to destroy
@@ -858,11 +859,12 @@ spec:
               continueResyncOnCommitMatch:
                 description: (optional) ContinueResyncOnCommitMatch - when true -
                   informs the operator to continue trying to update stacks even if
-                  the commit matches. This might be useful in environments where Pulumi
-                  programs have dynamic elements for example, calls to internal APIs
-                  where GitOps style commit tracking is not sufficient. Defaults to
-                  false, i.e. when a particular commit is successfully run, the operator
-                  will not attempt to rerun the program at that commit again.
+                  the revision of the source matches. This might be useful in environments
+                  where Pulumi programs have dynamic elements for example, calls to
+                  internal APIs where GitOps style commit tracking is not sufficient.  Defaults
+                  to false, i.e. when a particular revision is successfully run, the
+                  operator will not attempt to rerun the program at that revision
+                  again.
                 type: boolean
               destroyOnFinalize:
                 description: (optional) DestroyOnFinalize can be set to true to destroy

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -130,7 +130,7 @@ StackSpec defines the desired state of Pulumi Stack being managed by this operat
         <td><b>continueResyncOnCommitMatch</b></td>
         <td>boolean</td>
         <td>
-          (optional) ContinueResyncOnCommitMatch - when true - informs the operator to continue trying to update stacks even if the commit matches. This might be useful in environments where Pulumi programs have dynamic elements for example, calls to internal APIs where GitOps style commit tracking is not sufficient. Defaults to false, i.e. when a particular commit is successfully run, the operator will not attempt to rerun the program at that commit again.<br/>
+          (optional) ContinueResyncOnCommitMatch - when true - informs the operator to continue trying to update stacks even if the revision of the source matches. This might be useful in environments where Pulumi programs have dynamic elements for example, calls to internal APIs where GitOps style commit tracking is not sufficient.  Defaults to false, i.e. when a particular revision is successfully run, the operator will not attempt to rerun the program at that revision again.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -2016,7 +2016,7 @@ StackSpec defines the desired state of Pulumi Stack being managed by this operat
         <td><b>continueResyncOnCommitMatch</b></td>
         <td>boolean</td>
         <td>
-          (optional) ContinueResyncOnCommitMatch - when true - informs the operator to continue trying to update stacks even if the commit matches. This might be useful in environments where Pulumi programs have dynamic elements for example, calls to internal APIs where GitOps style commit tracking is not sufficient. Defaults to false, i.e. when a particular commit is successfully run, the operator will not attempt to rerun the program at that commit again.<br/>
+          (optional) ContinueResyncOnCommitMatch - when true - informs the operator to continue trying to update stacks even if the revision of the source matches. This might be useful in environments where Pulumi programs have dynamic elements for example, calls to internal APIs where GitOps style commit tracking is not sufficient.  Defaults to false, i.e. when a particular revision is successfully run, the operator will not attempt to rerun the program at that revision again.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/apis/pulumi/shared/stack_types.go
+++ b/pkg/apis/pulumi/shared/stack_types.go
@@ -75,6 +75,14 @@ type StackSpec struct {
 
 	// Lifecycle:
 
+	// (optional) ContinueResyncOnCommitMatch - when true - informs the operator to continue trying
+	// to update stacks even if the revision of the source matches. This might be useful in
+	// environments where Pulumi programs have dynamic elements for example, calls to internal APIs
+	// where GitOps style commit tracking is not sufficient.  Defaults to false, i.e. when a
+	// particular revision is successfully run, the operator will not attempt to rerun the program
+	// at that revision again.
+	ContinueResyncOnCommitMatch bool `json:"continueResyncOnCommitMatch,omitempty"`
+
 	// (optional) Refresh can be set to true to refresh the stack before it is updated.
 	Refresh bool `json:"refresh,omitempty"`
 	// (optional) ExpectNoRefreshChanges can be set to true if a stack is not expected to have
@@ -143,12 +151,6 @@ type GitSource struct {
 	// When specified, the operator will periodically poll to check if the branch has any new commits.
 	// The frequency of the polling is configurable through ResyncFrequencySeconds, defaulting to every 60 seconds.
 	Branch string `json:"branch,omitempty"`
-	// (optional) ContinueResyncOnCommitMatch - when true - informs the operator to continue trying to update stacks
-	// even if the commit matches. This might be useful in environments where Pulumi programs have dynamic elements
-	// for example, calls to internal APIs where GitOps style commit tracking is not sufficient.
-	// Defaults to false, i.e. when a particular commit is successfully run, the operator will not attempt to rerun the
-	// program at that commit again.
-	ContinueResyncOnCommitMatch bool `json:"continueResyncOnCommitMatch,omitempty"`
 }
 
 // GitAuthConfig specifies git authentication configuration options.


### PR DESCRIPTION
This moves the field `ContinueResyncOnCommitMatch` ("CRoCM") out to `.Spec`, from the embedded `.Spec.*GitSource`. This field applies to all sources, which have their own idea of what a "commit" is -- and indeed, the code for every kind of source (GitSource, FluxSource, ProgramRef) consults this field to see if it should run the stack:

https://github.com/pulumi/pulumi-kubernetes-operator/blob/72e41682ed51279dfb1375bfc756f43668babe84/pkg/controller/stack/stack_controller.go#L462

In doing so, there's an implicit pointer dereference -- .GitSource is pointer typed so it can be optional -- and the accompanying possibility of a nil pointer dereference (as encountered in #344). Moving the field eliminates this possibility.