### PR TITLE
Make permalink missing log entry for refresh less scary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 - Give an example of using this operator with a Flux GitRepository and webhooks, in
   `examples/flux-source`.
   [#339](https://github.com/pulumi/pulumi-kubernetes-operator/pull/339)
+- De-escalate a log message about a harmless error from ERROR to DEBUG
+  [#352](https://github.com/pulumi/pulumi-kubernetes-operator/pull/352)
 
 ## 1.10.0 (2022-10-21)
 

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -1203,7 +1203,7 @@ func (sess *reconcileStackSession) RefreshStack(ctx context.Context, expectNoCha
 	p, err := auto.GetPermalink(result.StdOut)
 	if err != nil {
 		// Successful update but no permalink suggests a backend which doesn't support permalinks. Ignore.
-		sess.logger.Error(err, "No permalink found.", "Namespace", sess.namespace)
+		sess.logger.Debug("No permalink found - ignoring.", "Stack.Name", sess.stack.Stack, "Namespace", sess.namespace)
 	}
 	permalink := shared.Permalink(p)
 	return permalink, nil


### PR DESCRIPTION
Apply the same fix as https://github.com/pulumi/pulumi-kubernetes-operator/pull/288 to the refresh path as well.