### PR TITLE
Remove some minor irritants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 - Expand the installation programs in deploy/ so they can deploy the operator to several namespaces
   in one go, as well as upgrade the operator version.
   [#328](https://github.com/pulumi/pulumi-kubernetes-operator/pull/328)
+- Avoid some needless and misleading log messages
+  [#363](https://github.com/pulumi/pulumi-kubernetes-operator/pull/363)
 
 ## 1.10.1 (2022-10-25)
 

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -1195,7 +1195,9 @@ func (sess *reconcileStackSession) ensureStackSettings(ctx context.Context, w au
 	// If not found, stackConfig will be a pointer to a zeroed-out workspace.ProjectStack.
 	stackConfig, err := w.StackSettings(ctx, sess.stack.Stack)
 	if err != nil {
-		sess.logger.Info("Missing stack config file. Will assume no stack config checked-in.", "Cause", err)
+		// .Info, when given a key "Error" and value of type `error`, will output a verbose error
+		// message, which adds noise to the stack. To avoid that, use the stringified error message.
+		sess.logger.Info("Missing stack config file. Will assume no stack config checked-in.", "Error", err.Error())
 		stackConfig = &workspace.ProjectStack{}
 	}
 

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -388,7 +388,10 @@ func (r *ReconcileStack) Reconcile(ctx context.Context, request reconcile.Reques
 			log.Error(err, "unable to save object status")
 		}
 	}
-	defer saveStatus()
+	// there's no reason to save the status if it's being deleted, and it'll fail anyway.
+	if !isStackMarkedToBeDeleted {
+		defer saveStatus()
+	}
 
 	// We're ready to do some actual work. Until we have a definitive outcome, mark the stack as
 	// reconciling.

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -1293,7 +1293,7 @@ func (sess *reconcileStackSession) InstallProjectDependencies(ctx context.Contex
 			return err
 		}
 		return nil
-	case "go", "dotnet":
+	case "go", "dotnet", "yaml":
 		// nothing needed
 		return nil
 	default:


### PR DESCRIPTION
This PR tidies some pretty harmless, but nonetheless irritating, little bugs:

 - there's a defer'ed hook for saving the Stack status upon exit from Reconcile -- don't try to run it if the object is being deleted, because it will fail
 - handle `yaml` runtime when setting up dependencies (by not doing anything), rather than complaining in the logs
 - don't log a stack trace just because there wasn't a file for the stack in the git repo -- that's totally normal
