### PR TITLE
Rewrite testdata/empty-stack for Pulumi YAML 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CHANGELOG
   [#363](https://github.com/pulumi/pulumi-kubernetes-operator/pull/363)
 - Bump Pulumi SDK to v3.46.0
   [#365](https://github.com/pulumi/pulumi-kubernetes-operator/pull/365)
+- Rewrite test case to confirm to Pulumi YAML 1.0 (breaking) changes
+  [#369](https://github.com/pulumi/pulumi-kubernetes-operator/pull/369)
 
 ## 1.10.1 (2022-10-25)
 

--- a/test/testdata/empty-stack/Pulumi.dev.yaml
+++ b/test/testdata/empty-stack/Pulumi.dev.yaml
@@ -1,2 +1,2 @@
 config:
-  aws:region: us-west-2
+  region: us-west-2

--- a/test/testdata/empty-stack/Pulumi.yaml
+++ b/test/testdata/empty-stack/Pulumi.yaml
@@ -2,13 +2,13 @@ name: empty-stack
 runtime: yaml
 description: A YAML program that does very little.
 configuration:
-  "aws:region": { type: 'String' }
+  "region": { type: 'String' }
 outputs:
-  region: ${aws:region}
+  region: ${region}
   notSoSecret: "safe"
   secretVal:
-    Fn::Secret: { "val": "very secret" }
+    fn::secret: { "val": "very secret" }
   nestedSecret:
     plain: "foo"
     secret:
-      Fn::Secret: "bar"
+      fn::secret: "bar"


### PR DESCRIPTION
Pulumi 3.46 comes with Pulumi YAML 1.0, and these bring an undocumented breaking change, which I have fixed here:
  - configuration duplicates are now forbidden, so use `region` rather than "aws:region"

This will at some point be a breaking change, but for now, to reduce complaints in the log:
 - use newly preferred camel-case spelling for function invocations e.g., fn::secret
