### PR TITLE
feat: add helm chart

### DIFF
--- a/.github/configs/cr.yaml
+++ b/.github/configs/cr.yaml
@@ -1,0 +1,2 @@
+## Reference: https://github.com/helm/chart-releaser
+index-path: "./index.yaml"

--- a/.github/configs/ct-install.yaml
+++ b/.github/configs/ct-install.yaml
@@ -1,0 +1,13 @@
+## Reference: https://github.com/helm/chart-testing/blob/master/doc/ct_lint-and-install.md
+# Don't add the 'debug' attribute, otherwise the workflow won't work anymore
+# Only Used for the CT Lint Stage
+remote: origin
+target-branch: master
+chart-dirs:
+  - deploy/helm
+helm-extra-args: "--timeout 600s"
+validate-chart-schema: false
+validate-maintainers: true
+validate-yaml: true
+exclude-deprecated: true
+excluded-charts: []

--- a/.github/configs/ct-lint.yaml
+++ b/.github/configs/ct-lint.yaml
@@ -1,0 +1,13 @@
+## Reference: https://github.com/helm/chart-testing/blob/master/doc/ct_lint-and-install.md
+# Don't add the 'debug' attribute, otherwise the workflow won't work anymore
+# Only Used for the CT Lint Stage
+remote: origin
+target-branch: master
+chart-dirs:
+  - deploy/helm
+helm-extra-args: "--timeout 600s"
+validate-chart-schema: false
+validate-maintainers: true
+validate-yaml: true
+exclude-deprecated: true
+excluded-charts: []

--- a/.github/configs/lintconf.yaml
+++ b/.github/configs/lintconf.yaml
@@ -1,0 +1,42 @@
+---
+rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    require-starting-space: true
+    min-spaces-from-content: 1
+  document-end: disable
+  document-start: disable # No --- to start a file
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: consistent
+    indent-sequences: whatever # - list indentation will handle both indentation and without
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length: disable # Lines can be any length
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  trailing-spaces: enable
+  truthy:
+    level: warning

--- a/.github/workflows/chart-lint-and-test.yml
+++ b/.github/workflows/chart-lint-and-test.yml
@@ -1,0 +1,75 @@
+name: ct-linting-and-testing
+on:
+  pull_request:
+    paths:
+      - deploy/helm/**
+
+permissions: read-all
+
+jobs:
+  chart-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@f382f75448129b3be48f8121b9857be18d815a82 # tag=v3.4
+        with:
+          version: v3.6.3
+
+      - name: Set up python
+        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # tag=v4.3.0
+        with:
+          python-version: 3.7
+
+      - name: Run Trivy vulnerability scanner in IaC mode
+        uses: aquasecurity/trivy-action@9ab158e8597f3b310480b9a69402b419bc03dbd5 # tag=0.8.0
+        with:
+          scan-type: 'config'
+          hide-progress: false
+          format: 'sarif'
+          scan-ref: 'deploy/helm/pulumi-operator'
+          output: 'trivy-results.sarif'
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@312e093a1892bd801f026f1090904ee8e460b9b6 # v2.1.34
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+      - name: Setup Chart Linting
+        id: lint
+        uses: helm/chart-testing-action@afea100a513515fbd68b0e72a7bb0ae34cb62aec # tag=v2.3.1
+
+      - name: List changed charts
+        id: list-changed
+        run: |
+          ## If executed with debug this won't work anymore.
+          changed=$(ct --config ./.github/configs/ct-lint.yaml list-changed)
+          charts=$(echo "$changed" | tr '\n' ' ' | xargs)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+            echo "::set-output name=changed_charts::$charts"
+          fi
+
+      - name: Run Artifact Hub lint
+        run: |
+          curl -s https://api.github.com/repos/artifacthub/hub/releases/latest | grep -E 'browser_download_url' | grep linux_amd64.tar.gz\" | grep -Eo 'https://[^\"]*' | xargs wget -O - | tar -xz
+          ./ah lint -p deploy/helm/pulumi-operator || exit 1
+          rm -f ./ah
+
+      - name: Run chart-testing (lint)
+        run: ct lint --debug --config ./.github/configs/ct-lint.yaml --lint-conf ./.github/configs/lintconf.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@9e8295d178de23cbfbd8fa16cf844eec1d773a07 # tag=v1.4.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config ./.github/configs/ct-lint.yaml
+        if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/chart-lint-and-test.yml
+++ b/.github/workflows/chart-lint-and-test.yml
@@ -11,22 +11,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@f382f75448129b3be48f8121b9857be18d815a82 # tag=v3.4
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
           version: v3.6.3
 
       - name: Set up python
-        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # tag=v4.3.0
+        uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b # v4.6.0
         with:
           python-version: 3.7
 
       - name: Run Trivy vulnerability scanner in IaC mode
-        uses: aquasecurity/trivy-action@9ab158e8597f3b310480b9a69402b419bc03dbd5 # tag=0.8.0
+        uses: aquasecurity/trivy-action@e5f43133f6e8736992c9f3c1b3296e24b37e17f2 # 0.10.0
         with:
           scan-type: 'config'
           hide-progress: false
@@ -38,13 +38,13 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@312e093a1892bd801f026f1090904ee8e460b9b6 # v2.1.34
+        uses: github/codeql-action/upload-sarif@f3feb00acb00f31a6f60280e6ace9ca31d91c76a # v2.3.2
         with:
           sarif_file: 'trivy-results.sarif'
 
       - name: Setup Chart Linting
         id: lint
-        uses: helm/chart-testing-action@afea100a513515fbd68b0e72a7bb0ae34cb62aec # tag=v2.3.1
+        uses: helm/chart-testing-action@e8788873172cb653a90ca2e819d79d65a66d4e76 # v2.4.0
 
       - name: List changed charts
         id: list-changed
@@ -67,7 +67,7 @@ jobs:
         run: ct lint --debug --config ./.github/configs/ct-lint.yaml --lint-conf ./.github/configs/lintconf.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@9e8295d178de23cbfbd8fa16cf844eec1d773a07 # tag=v1.4.0
+        uses: helm/kind-action@d8ccf8fb623ce1bb360ae2f45f323d9d5c5e9f00 # v1.5.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -1,0 +1,79 @@
+---
+name: chart-publish
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "deploy/helm/**"
+env:
+  HELM_DOCS_VERSION: "1.11.0"
+
+permissions: read-all
+
+jobs:
+  publish:
+    permissions:
+      contents: write # for helm/chart-releaser-action to push chart release and create a release
+      packages: write # for helm/chart-releaser-action to push chart release and create a release
+      id-token: write # for helm/chart-releaser-action to push chart release and create a release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@f382f75448129b3be48f8121b9857be18d815a82 # tag=v3.4
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: install helm-docs
+        run: |
+          cd /tmp
+          wget https://github.com/norwoodj/helm-docs/releases/download/v${{env.HELM_DOCS_VERSION}}/helm-docs_${{env.HELM_DOCS_VERSION}}_Linux_x86_64.tar.gz
+          tar -xvf helm-docs_${{env.HELM_DOCS_VERSION}}_Linux_x86_64.tar.gz
+          sudo mv helm-docs /usr/local/sbin
+
+      - name: run helm-docs
+        run: |
+          helm-docs -t README.md.gotmpl -o README.md -b for-the-badge
+
+      - name: Login to GHCR
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # tag=v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${ GITHUB_REPOSITORY_OWNER }
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Artifact Hub lint
+        run: |
+          curl -s https://api.github.com/repos/artifacthub/hub/releases/latest | grep -E 'browser_download_url' | grep linux_amd64.tar.gz\" | grep -Eo 'https://[^\"]*' | xargs wget -O - | tar -xz
+          ./ah lint -p deploy/helm/pulumi-operator || exit 1
+          rm -f ./ah
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@98bccfd32b0f76149d188912ac8e45ddd3f8695f # tag=v1.4.1
+        with:
+          config: "./.github/configs/cr.yaml"
+          charts_dir: "deploy/helm"
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # tag=v2.8.1
+      - name: Push chart to GHCR
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*; do
+            if [ -z "${pkg:-}" ]; then
+              break
+            fi
+            helm push "${pkg}" oci://ghcr.io/pulumi/charts |& tee .digest
+            cosign sign $(cat .digest | awk -F "[, ]+" '/Pushed/{print $NF}')
+          done          

--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -74,6 +74,6 @@ jobs:
             if [ -z "${pkg:-}" ]; then
               break
             fi
-            helm push "${pkg}" oci://ghcr.io/pulumi/charts |& tee .digest
+            helm push "${pkg}" oci://ghcr.io/pulumi/helm-charts |& tee .digest
             cosign sign -y $(cat .digest | awk -F "[, ]+" '/Pushed/{print $NF}')
           done          

--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           fetch-depth: 0
 
       - name: Install Helm
-        uses: azure/setup-helm@f382f75448129b3be48f8121b9857be18d815a82 # tag=v3.4
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
 
       - name: Configure Git
         run: |
@@ -57,14 +57,14 @@ jobs:
           rm -f ./ah
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@98bccfd32b0f76149d188912ac8e45ddd3f8695f # tag=v1.4.1
+        uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # v1.5.0
         with:
           config: "./.github/configs/cr.yaml"
           charts_dir: "deploy/helm"
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-      - uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # tag=v2.8.1
+      - uses: sigstore/cosign-installer@204a51a57a74d190b284a0ce69b44bc37201f343 # v3.0.3
       - name: Push chart to GHCR
         env:
           COSIGN_EXPERIMENTAL: 1
@@ -75,5 +75,5 @@ jobs:
               break
             fi
             helm push "${pkg}" oci://ghcr.io/pulumi/charts |& tee .digest
-            cosign sign $(cat .digest | awk -F "[, ]+" '/Pushed/{print $NF}')
+            cosign sign -y $(cat .digest | awk -F "[, ]+" '/Pushed/{print $NF}')
           done          

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## HEAD (unreleased)
 - Use digest field for Flux source artifact if present [#459](https://github.com/pulumi/pulumi-kubernetes-operator/pull/459)
+- Add Helm chart support for installing the Pulumi Operator. [#379](https://github.com/pulumi/pulumi-kubernetes-operator/pull/379)
 
 ## 1.12.1 (2023-05-19)
 - Update to [Pulumi SDK v3.68.0](https://github.com/pulumi/pulumi/releases/tag/v3.68.0) and the base

--- a/deploy/helm/pulumi-operator/.helmignore
+++ b/deploy/helm/pulumi-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/pulumi-operator/Chart.yaml
+++ b/deploy/helm/pulumi-operator/Chart.yaml
@@ -1,0 +1,38 @@
+apiVersion: v2
+name: pulumi-kubernetes-operator
+description: A Helm chart for the Pulumi Kubernetes Operator
+home: https://pulumi.com
+sources:
+  - https://github.com/pulumi/pulumi-kubernetes-operator
+
+icon: https://www.pulumi.com/logos/brand/twitter-card.png
+
+type: application
+
+version: 0.1.0
+appVersion: "1.10.1"
+
+keywords:
+  - pulumi
+  - kubernetes
+  - operator
+
+maintainers:
+  - name: dirien
+    email: engin@pulumi.com
+    url: https://pulumi.com
+
+annotations:
+  artifacthub.io/containsSecurityUpdates: "false"
+  artifacthub.io/changes: |
+    - initial release
+  artifacthub.io/images: |
+    - name: pulumi-kubernetes-operator
+      image: docker.io/pulumi-kubernetes-operator:v1.10.1
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: website
+      url: https://pulumi.com
+  artifacthub.io/maintainers: |
+    - name: dirien
+      email: engin@pulumi.com

--- a/deploy/helm/pulumi-operator/README.md
+++ b/deploy/helm/pulumi-operator/README.md
@@ -1,0 +1,124 @@
+# node-red ⚙
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 1.10.1](https://img.shields.io/badge/AppVersion-1.10.1-informational?style=for-the-badge)
+
+## Description 📜
+
+A Helm chart for the Pulumi Kubernetes Operator
+
+## Usage (via OCI Registry)
+
+To install the chart using the OCI artifact, run:
+
+```bash
+helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/charts/pulumi-kubernetes-operator --version 0.1.0
+```
+
+## Usage
+Adding `pulumi-kubernetes-operator` repository
+Before installing any chart provided by this repository, add the `pulumi-kubernetes-operator` Charts Repository:
+
+```bash
+helm repo add pulumi-kubernetes-operator https://pulumi.github.io/pulumi-kubernetes-operator/
+helm repo update
+```
+
+### Installing the Chart 📦
+To install the chart with the release name `pulumi-kubernetes-operator` run:
+
+```bash
+helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --version 0.1.0
+```
+
+After a few seconds, the `pulumi-kubernetes-operator` should be running.
+
+To install the chart in a specific namespace use following commands:
+
+```bash
+kubectl create ns pulumi-kubernetes-operator
+helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --namespace pulumi-kubernetes-operator
+```
+
+> **Tip**: List all releases using `helm list`, a release is a name used to track a specific deployment
+
+### Uninstalling the Chart 🗑️
+
+To uninstall the `pulumi-kubernetes-operator` deployment:
+
+```bash
+helm uninstall pulumi-kubernetes-operator
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | The affinity constraint |
+| controller.args | list | `["--zap-level=error","--zap-time-encoding=iso8601"]` | List of arguments to pass to the operator |
+| controller.gracefulShutdownTimeoutDuration | string | `"5m"` | Graceful shutdown timeout duration, default: `5m` |
+| controller.kubernetesClusterDomain | string | `"cluster.local"` | Kubernetes Cluster Domain, default: `cluster.local` |
+| controller.maxConcurrentReconciles | string | `"10"` | Max concurrent reconciles, default: `10` |
+| controller.pulumiInferNamespace | string | `"1"` | Pulumi infer namespace, default: `1` |
+| deploymentAnnotations | object | `{}` | Deployment annotations |
+| deploymentStrategy | string | `""` | Specifies the strategy used to replace old Pods by new ones, default: `RollingUpdate` |
+| extraEnv | list | `[]` | Extra Environments to be passed to the operator |
+| extraSidecars | list | `[]` | You can configure extra sidecars containers to run alongside the pulumi-kubernetes-operator pod. default: [] |
+| extraVolumeMounts | string | `nil` | Extra Volume Mounts for the pulumi-kubernetes-operator pod |
+| extraVolumes | string | `nil` | Extra Volumes for the pod |
+| fullnameOverride | string | `""` | String to fully override "pulumi-kubernetes-operator.fullname" |
+| image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
+| image.registry | string | `"docker.io"` | The image registry to pull from |
+| image.repository | string | `"pulumi/pulumi-kubernetes-operator"` | The image repository to pull from |
+| image.tag | string | `""` | The image tag to pull, default: `Chart.appVersion` |
+| imagePullSecrets | string | `""` | The image pull secrets |
+| initContainers | list | `[]` | containers which are run before the app containers are started |
+| nameOverride | string | `""` | Provide a name in place of pulumi-kubernetes-operator |
+| nodeSelector | object | `{}` | Node selector |
+| podAnnotations | object | `{}` | Pod annotations |
+| podLabels | object | `{}` | Labels to add to the pulumi-kubernetes-operator pod. default: {} |
+| podSecurityContext | object | `{"fsGroup":1000,"runAsUser":1000}` | Pod Security Context see [values.yaml](values.yaml) |
+| podSecurityContext.fsGroup | int | `1000` | pulumi-kubernetes-operator group is 1000 |
+| podSecurityContext.runAsUser | int | `1000` | pulumi-kubernetes-operator user is 1000 |
+| replicaCount | int | `1` | Specifies the replica count for the deployment |
+| resources | object | `{"limits":{"cpu":"500m","memory":"5123Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | CPU/Memory resource requests/limits |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"runAsGroup":10003,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security Context see [values.yaml](values.yaml) |
+| serviceAccount.annotations | object | `{}` | Additional ServiceAccount annotations |
+| serviceAccount.create | bool | `true` | Create service account |
+| serviceAccount.name | string | `""` | Service account name to use, when empty will be set to created account if |
+| tolerations | list | `[]` | Toleration labels for pod assignment |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --set image.tag=latest
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Contributing 🤝
+
+### Contributing via GitHub
+
+Feel free to join. Checkout the [contributing guide](CONTRIBUTING.md)
+
+## License ⚖️
+
+Apache License, Version 2.0
+
+## Source Code
+
+* <https://github.com/pulumi/pulumi-kubernetes-operator>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| dirien | <engin@pulumi.com> | <https://pulumi.com> |

--- a/deploy/helm/pulumi-operator/README.md
+++ b/deploy/helm/pulumi-operator/README.md
@@ -87,6 +87,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | serviceAccount.annotations | object | `{}` | Additional ServiceAccount annotations |
 | serviceAccount.create | bool | `true` | Create service account |
 | serviceAccount.name | string | `""` | Service account name to use, when empty will be set to created account if |
+| serviceMonitor.enabled | bool | `false` | When set true then use a ServiceMonitor to configure scraping |
 | tolerations | list | `[]` | Toleration labels for pod assignment |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/deploy/helm/pulumi-operator/README.md
+++ b/deploy/helm/pulumi-operator/README.md
@@ -11,7 +11,7 @@ A Helm chart for the Pulumi Kubernetes Operator
 To install the chart using the OCI artifact, run:
 
 ```bash
-helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/charts/pulumi-kubernetes-operator --version 0.1.0
+helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator --version 0.1.0
 ```
 
 ## Usage

--- a/deploy/helm/pulumi-operator/README.md.gotmpl
+++ b/deploy/helm/pulumi-operator/README.md.gotmpl
@@ -1,0 +1,82 @@
+# node-red ⚙
+
+{{ template "chart.badgesSection" . }}
+
+## Description 📜
+
+{{ template "chart.description" . }}
+
+## Usage (via OCI Registry)
+
+To install the chart using the OCI artifact, run:
+
+```bash
+helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/charts/pulumi-kubernetes-operator --version {{ .Version }}
+```
+
+## Usage
+Adding `pulumi-kubernetes-operator` repository
+Before installing any chart provided by this repository, add the `pulumi-kubernetes-operator` Charts Repository:
+
+```bash
+helm repo add pulumi-kubernetes-operator https://pulumi.github.io/pulumi-kubernetes-operator/
+helm repo update
+```
+
+### Installing the Chart 📦
+To install the chart with the release name `pulumi-kubernetes-operator` run:
+
+```bash
+helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --version {{ .Version }}
+```
+
+After a few seconds, the `pulumi-kubernetes-operator` should be running.
+
+To install the chart in a specific namespace use following commands:
+
+```bash
+kubectl create ns pulumi-kubernetes-operator
+helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --namespace pulumi-kubernetes-operator
+```
+
+> **Tip**: List all releases using `helm list`, a release is a name used to track a specific deployment
+
+### Uninstalling the Chart 🗑️
+
+To uninstall the `pulumi-kubernetes-operator` deployment:
+
+```bash
+helm uninstall pulumi-kubernetes-operator
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+{{ template "chart.valuesSection" . }}
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --set image.tag=latest
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Contributing 🤝
+
+### Contributing via GitHub
+
+Feel free to join. Checkout the [contributing guide](CONTRIBUTING.md)
+
+## License ⚖️
+
+Apache License, Version 2.0
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.maintainersSection" . }}

--- a/deploy/helm/pulumi-operator/README.md.gotmpl
+++ b/deploy/helm/pulumi-operator/README.md.gotmpl
@@ -11,7 +11,7 @@
 To install the chart using the OCI artifact, run:
 
 ```bash
-helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/charts/pulumi-kubernetes-operator --version {{ .Version }}
+helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator --version {{ .Version }}
 ```
 
 ## Usage

--- a/deploy/helm/pulumi-operator/crds/program-crd.yaml
+++ b/deploy/helm/pulumi-operator/crds/program-crd.yaml
@@ -1,0 +1,186 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: programs.pulumi.com
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+spec:
+  group: pulumi.com
+  names:
+    kind: Program
+    listKind: ProgramList
+    plural: programs
+    singular: program
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Program is the schema for the inline YAML program API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          program:
+            properties:
+              configuration:
+                additionalProperties:
+                  properties:
+                    default:
+                      description: default is a value of the appropriate type for the
+                        template to use if no value is specified.
+                      x-kubernetes-preserve-unknown-fields: true
+                    type:
+                      description: type is the (required) data type for the parameter.
+                      enum:
+                      - String
+                      - Number
+                      - List<Number>
+                      - List<String>
+                      type: string
+                  type: object
+                description: configuration specifies the Pulumi config inputs to the
+                  deployment. Either type or default is required.
+                type: object
+              outputs:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: outputs specifies the Pulumi stack outputs of the program
+                  and how they are computed from the resources.
+                type: object
+              resources:
+                additionalProperties:
+                  properties:
+                    get:
+                      description: A getter function for the resource. Supplying get
+                        is mutually exclusive to properties.
+                      properties:
+                        id:
+                          description: The ID of the resource to import.
+                          minLength: 1
+                          type: string
+                        state:
+                          additionalProperties:
+                            x-kubernetes-preserve-unknown-fields: true
+                          description: state contains the known properties (input &
+                            output) of the resource. This assists the provider in figuring
+                            out the correct resource.
+                          type: object
+                      required:
+                      - id
+                      type: object
+                    options:
+                      description: options contains all resource options supported by
+                        Pulumi.
+                      properties:
+                        additionalSecretOutputs:
+                          description: additionalSecretOutputs specifies properties
+                            that must be encrypted as secrets.
+                          items:
+                            type: string
+                          type: array
+                        aliases:
+                          description: aliases specifies names that this resource used
+                            to have, so that renaming or refactoring doesn’t replace
+                            it.
+                          items:
+                            type: string
+                          type: array
+                        customTimeouts:
+                          description: customTimeouts overrides the default retry/timeout
+                            behavior for resource provisioning.
+                          properties:
+                            create:
+                              description: create is the custom timeout for create operations.
+                              type: string
+                            delete:
+                              description: delete is the custom timeout for delete operations.
+                              type: string
+                            update:
+                              description: update is the custom timeout for update operations.
+                              type: string
+                          type: object
+                        deleteBeforeReplace:
+                          description: deleteBeforeReplace overrides the default create-before-delete
+                            behavior when replacing.
+                          type: boolean
+                        dependsOn:
+                          description: dependsOn adds explicit dependencies in addition
+                            to the ones in the dependency graph.
+                          items:
+                            x-kubernetes-preserve-unknown-fields: true
+                          type: array
+                        ignoreChanges:
+                          description: ignoreChanges declares that changes to certain
+                            properties should be ignored when diffing.
+                          items:
+                            type: string
+                          type: array
+                        import:
+                          description: import adopts an existing resource from your
+                            cloud account under the control of Pulumi.
+                          type: string
+                        parent:
+                          description: parent resource option specifies a parent for
+                            a resource. It is used to associate children with the parents
+                            that encapsulate or are responsible for them.
+                          x-kubernetes-preserve-unknown-fields: true
+                        protect:
+                          description: protect prevents accidental deletion of a resource.
+                          type: boolean
+                        provider:
+                          description: provider resource option sets a provider for
+                            the resource.
+                          x-kubernetes-preserve-unknown-fields: true
+                        providers:
+                          additionalProperties:
+                            x-kubernetes-preserve-unknown-fields: true
+                          description: providers resource option sets a map of providers
+                            for the resource and its children.
+                          type: object
+                        version:
+                          description: version specifies a provider plugin version that
+                            should be used when operating on a resource.
+                          type: string
+                      type: object
+                    properties:
+                      additionalProperties:
+                        x-kubernetes-preserve-unknown-fields: true
+                      description: properties contains the primary resource-specific
+                        keys and values to initialize the resource state.
+                      type: object
+                    type:
+                      description: type is the Pulumi type token for this resource.
+                      minLength: 1
+                      type: string
+                  required:
+                  - type
+                  type: object
+                description: resources declares the Pulumi resources that will be deployed
+                  and managed by the program.
+                type: object
+              variables:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: variables specifies intermediate values of the program;
+                  the values of variables are expressions that can be re-used.
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/helm/pulumi-operator/crds/stack-crd.yaml
+++ b/deploy/helm/pulumi-operator/crds/stack-crd.yaml
@@ -1,0 +1,1465 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: stacks.pulumi.com
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+spec:
+  group: pulumi.com
+  names:
+    kind: Stack
+    listKind: StackList
+    plural: stacks
+    singular: stack
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.lastUpdate.state
+      name: State
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Stack is the Schema for the stacks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StackSpec defines the desired state of Pulumi Stack being managed
+              by this operator.
+            properties:
+              accessTokenSecret:
+                description: '(optional) AccessTokenSecret is the name of a secret containing
+                  the PULUMI_ACCESS_TOKEN for Pulumi access. Deprecated: use EnvRefs
+                  with a "secret" entry with the key PULUMI_ACCESS_TOKEN instead.'
+                type: string
+              backend:
+                description: '(optional) Backend is an optional backend URL to use for
+                  all Pulumi operations.<br/> Examples:<br/> - Pulumi Service:              "https://app.pulumi.com"
+                  (default)<br/> - Self-managed Pulumi Service: "https://pulumi.acmecorp.com"
+                  <br/> - Local:                       "file://./einstein" <br/> - AWS:                         "s3://<my-pulumi-state-bucket>"
+                  <br/> - Azure:                       "azblob://<my-pulumi-state-bucket>"
+                  <br/> - GCP:                         "gs://<my-pulumi-state-bucket>"
+                  <br/> See: https://www.pulumi.com/docs/intro/concepts/state/'
+                type: string
+              branch:
+                description: (optional) Branch is the branch name to deploy, either
+                  the simple or fully qualified ref name, e.g. refs/heads/master. This
+                  is mutually exclusive with the Commit setting. Either value needs
+                  to be specified. When specified, the operator will periodically poll
+                  to check if the branch has any new commits. The frequency of the polling
+                  is configurable through ResyncFrequencySeconds, defaulting to every
+                  60 seconds.
+                type: string
+              commit:
+                description: (optional) Commit is the hash of the commit to deploy.
+                  If used, HEAD will be in detached mode. This is mutually exclusive
+                  with the Branch setting. Either value needs to be specified.
+                type: string
+              config:
+                additionalProperties:
+                  type: string
+                description: (optional) Config is the configuration for this stack,
+                  which can be optionally specified inline. If this is omitted, configuration
+                  is assumed to be checked in and taken from the source repository.
+                type: object
+              continueResyncOnCommitMatch:
+                description: (optional) ContinueResyncOnCommitMatch - when true - informs
+                  the operator to continue trying to update stacks even if the revision
+                  of the source matches. This might be useful in environments where
+                  Pulumi programs have dynamic elements for example, calls to internal
+                  APIs where GitOps style commit tracking is not sufficient.  Defaults
+                  to false, i.e. when a particular revision is successfully run, the
+                  operator will not attempt to rerun the program at that revision again.
+                type: boolean
+              destroyOnFinalize:
+                description: (optional) DestroyOnFinalize can be set to true to destroy
+                  the stack completely upon deletion of the CRD.
+                type: boolean
+              envRefs:
+                additionalProperties:
+                  description: ResourceRef identifies a resource from which information
+                    can be loaded. Environment variables, files on the filesystem, Kubernetes
+                    secrets and literal strings are currently supported.
+                  properties:
+                    env:
+                      description: Env selects an environment variable set on the operator
+                        process
+                      properties:
+                        name:
+                          description: Name of the environment variable
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    filesystem:
+                      description: FileSystem selects a file on the operator's file
+                        system
+                      properties:
+                        path:
+                          description: Path on the filesystem to use to load information
+                            from.
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    literal:
+                      description: LiteralRef refers to a literal value
+                      properties:
+                        value:
+                          description: Value to load
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    secret:
+                      description: SecretRef refers to a Kubernetes secret
+                      properties:
+                        key:
+                          description: Key within the secret to use.
+                          type: string
+                        name:
+                          description: Name of the secret
+                          type: string
+                        namespace:
+                          description: Namespace where the secret is stored. Deprecated;
+                            non-empty values will be considered invalid unless namespace
+                            isolation is disabled in the controller.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type:
+                      description: 'SelectorType is required and signifies the type
+                        of selector. Must be one of: Env, FS, Secret, Literal'
+                      type: string
+                  required:
+                  - type
+                  type: object
+                description: (optional) EnvRefs is an optional map containing environment
+                  variables as keys and stores descriptors to where the variables' values
+                  should be loaded from (one of literal, environment variable, file
+                  on the filesystem, or Kubernetes secret) as values.
+                type: object
+              envSecrets:
+                description: '(optional) SecretEnvs is an optional array of secret names
+                  containing environment variables to set. Deprecated: use EnvRefs instead.'
+                items:
+                  type: string
+                type: array
+              envs:
+                description: '(optional) Envs is an optional array of config maps containing
+                  environment variables to set. Deprecated: use EnvRefs instead.'
+                items:
+                  type: string
+                type: array
+              expectNoRefreshChanges:
+                description: (optional) ExpectNoRefreshChanges can be set to true if
+                  a stack is not expected to have changes during a refresh before the
+                  update is run. This could occur, for example, is a resource's state
+                  is changing outside of Pulumi (e.g., metadata, timestamps).
+                type: boolean
+              fluxSource:
+                description: FluxSource specifies how to fetch source code from a Flux
+                  source object.
+                properties:
+                  dir:
+                    description: Dir gives the subdirectory containing the Pulumi project
+                      (i.e., containing Pulumi.yaml) of interest, within the fetched
+                      source.
+                    type: string
+                  sourceRef:
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    type: object
+                required:
+                - sourceRef
+                type: object
+              gitAuth:
+                description: '(optional) GitAuth allows configuring git authentication
+                  options There are 3 different authentication options: * SSH private
+                  key (and its optional password) * Personal access token * Basic auth
+                  username and password Only one authentication mode will be considered
+                  if more than one option is specified, with ssh private key/password
+                  preferred first, then personal access token, and finally basic auth
+                  credentials.'
+                properties:
+                  accessToken:
+                    description: ResourceRef identifies a resource from which information
+                      can be loaded. Environment variables, files on the filesystem,
+                      Kubernetes secrets and literal strings are currently supported.
+                    properties:
+                      env:
+                        description: Env selects an environment variable set on the
+                          operator process
+                        properties:
+                          name:
+                            description: Name of the environment variable
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      filesystem:
+                        description: FileSystem selects a file on the operator's file
+                          system
+                        properties:
+                          path:
+                            description: Path on the filesystem to use to load information
+                              from.
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      literal:
+                        description: LiteralRef refers to a literal value
+                        properties:
+                          value:
+                            description: Value to load
+                            type: string
+                        required:
+                        - value
+                        type: object
+                      secret:
+                        description: SecretRef refers to a Kubernetes secret
+                        properties:
+                          key:
+                            description: Key within the secret to use.
+                            type: string
+                          name:
+                            description: Name of the secret
+                            type: string
+                          namespace:
+                            description: Namespace where the secret is stored. Deprecated;
+                              non-empty values will be considered invalid unless namespace
+                              isolation is disabled in the controller.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      type:
+                        description: 'SelectorType is required and signifies the type
+                          of selector. Must be one of: Env, FS, Secret, Literal'
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  basicAuth:
+                    description: BasicAuth configures git authentication through basic
+                      auth — i.e. username and password. Both UserName and Password
+                      are required.
+                    properties:
+                      password:
+                        description: ResourceRef identifies a resource from which information
+                          can be loaded. Environment variables, files on the filesystem,
+                          Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on
+                              the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's
+                              file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information
+                                  from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Deprecated;
+                                  non-empty values will be considered invalid unless
+                                  namespace isolation is disabled in the controller.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the
+                              type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      userName:
+                        description: ResourceRef identifies a resource from which information
+                          can be loaded. Environment variables, files on the filesystem,
+                          Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on
+                              the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's
+                              file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information
+                                  from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Deprecated;
+                                  non-empty values will be considered invalid unless
+                                  namespace isolation is disabled in the controller.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the
+                              type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - password
+                    - userName
+                    type: object
+                  sshAuth:
+                    description: SSHAuth configures ssh-based auth for git authentication.
+                      SSHPrivateKey is required but password is optional.
+                    properties:
+                      password:
+                        description: ResourceRef identifies a resource from which information
+                          can be loaded. Environment variables, files on the filesystem,
+                          Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on
+                              the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's
+                              file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information
+                                  from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Deprecated;
+                                  non-empty values will be considered invalid unless
+                                  namespace isolation is disabled in the controller.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the
+                              type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      sshPrivateKey:
+                        description: ResourceRef identifies a resource from which information
+                          can be loaded. Environment variables, files on the filesystem,
+                          Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on
+                              the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's
+                              file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information
+                                  from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Deprecated;
+                                  non-empty values will be considered invalid unless
+                                  namespace isolation is disabled in the controller.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the
+                              type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - sshPrivateKey
+                    type: object
+                type: object
+              gitAuthSecret:
+                description: '(optional) GitAuthSecret is the the name of a secret containing
+                  an authentication option for the git repository. There are 3 different
+                  authentication options: * Personal access token * SSH private key
+                  (and it''s optional password) * Basic auth username and password Only
+                  one authentication mode will be considered if more than one option
+                  is specified, with ssh private key/password preferred first, then
+                  personal access token, and finally basic auth credentials. Deprecated.
+                  Use GitAuth instead.'
+                type: string
+              programRef:
+                description: ProgramRef refers to a Program object, to be used as the
+                  source for the stack.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              projectRepo:
+                description: ProjectRepo is the git source control repository from which
+                  we fetch the project code and configuration.
+                type: string
+              refresh:
+                description: (optional) Refresh can be set to true to refresh the stack
+                  before it is updated.
+                type: boolean
+              repoDir:
+                description: (optional) RepoDir is the directory to work from in the
+                  project's source repository where Pulumi.yaml is located. It is used
+                  in case Pulumi.yaml is not in the project source root.
+                type: string
+              resyncFrequencySeconds:
+                description: (optional) ResyncFrequencySeconds when set to a non-zero
+                  value, triggers a resync of the stack at the specified frequency even
+                  if no changes to the custom-resource are detected. If branch tracking
+                  is enabled (branch is non-empty), commit polling will occur at this
+                  frequency. The minimal resync frequency supported is 60 seconds.
+                format: int64
+                type: integer
+              retryOnUpdateConflict:
+                description: (optional) RetryOnUpdateConflict issues a stack update
+                  retry reconciliation loop in the event that the update hits a HTTP
+                  409 conflict due to another update in progress. This is only recommended
+                  if you are sure that the stack updates are idempotent, and if you
+                  are willing to accept retry loops until all spawned retries succeed.
+                  This will also create a more populated, and randomized activity timeline
+                  for the stack in the Pulumi Service.
+                type: boolean
+              secrets:
+                additionalProperties:
+                  type: string
+                description: '(optional) Secrets is the secret configuration for this
+                  stack, which can be optionally specified inline. If this is omitted,
+                  secrets configuration is assumed to be checked in and taken from the
+                  source repository. Deprecated: use SecretRefs instead.'
+                type: object
+              secretsProvider:
+                description: '(optional) SecretsProvider is used to initialize a Stack
+                  with alternative encryption. Examples: - AWS:   "awskms:///arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34bc-56ef-1234567890ab?region=us-east-1"
+                  - Azure: "azurekeyvault://acmecorpvault.vault.azure.net/keys/mykeyname"
+                  - GCP:   "gcpkms://projects/MYPROJECT/locations/MYLOCATION/keyRings/MYKEYRING/cryptoKeys/MYKEY"
+                  - See: https://www.pulumi.com/docs/intro/concepts/secrets/#initializing-a-stack-with-alternative-encryption'
+                type: string
+              secretsRef:
+                additionalProperties:
+                  description: ResourceRef identifies a resource from which information
+                    can be loaded. Environment variables, files on the filesystem, Kubernetes
+                    secrets and literal strings are currently supported.
+                  properties:
+                    env:
+                      description: Env selects an environment variable set on the operator
+                        process
+                      properties:
+                        name:
+                          description: Name of the environment variable
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    filesystem:
+                      description: FileSystem selects a file on the operator's file
+                        system
+                      properties:
+                        path:
+                          description: Path on the filesystem to use to load information
+                            from.
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    literal:
+                      description: LiteralRef refers to a literal value
+                      properties:
+                        value:
+                          description: Value to load
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    secret:
+                      description: SecretRef refers to a Kubernetes secret
+                      properties:
+                        key:
+                          description: Key within the secret to use.
+                          type: string
+                        name:
+                          description: Name of the secret
+                          type: string
+                        namespace:
+                          description: Namespace where the secret is stored. Deprecated;
+                            non-empty values will be considered invalid unless namespace
+                            isolation is disabled in the controller.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type:
+                      description: 'SelectorType is required and signifies the type
+                        of selector. Must be one of: Env, FS, Secret, Literal'
+                      type: string
+                  required:
+                  - type
+                  type: object
+                description: (optional) SecretRefs is the secret configuration for this
+                  stack which can be specified through ResourceRef. If this is omitted,
+                  secrets configuration is assumed to be checked in and taken from the
+                  source repository.
+                type: object
+              stack:
+                description: Stack is the fully qualified name of the stack to deploy
+                  (<org>/<stack>).
+                type: string
+              useLocalStackOnly:
+                description: (optional) UseLocalStackOnly can be set to true to prevent
+                  the operator from creating stacks that do not exist in the tracking
+                  git repo. The default behavior is to create a stack if it doesn't
+                  exist.
+                type: boolean
+            required:
+            - stack
+            type: object
+          status:
+            description: StackStatus defines the observed state of Stack
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details
+                        about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers of
+                        specific condition types may define expected values and meanings
+                        for this field, and whether the values are considered a guaranteed
+                        API. The value should be a CamelCase string. This field may
+                        not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastUpdate:
+                description: LastUpdate contains details of the status of the last update.
+                properties:
+                  lastAttemptedCommit:
+                    description: Last commit attempted
+                    type: string
+                  lastResyncTime:
+                    description: LastResyncTime contains a timestamp for the last time
+                      a resync of the stack took place.
+                    format: date-time
+                    type: string
+                  lastSuccessfulCommit:
+                    description: Last commit successfully applied
+                    type: string
+                  permalink:
+                    description: Permalink is the Pulumi Console URL of the stack operation.
+                    type: string
+                  state:
+                    description: State is the state of the stack update - one of `succeeded`
+                      or `failed`
+                    type: string
+                type: object
+              observedGeneration:
+                description: ObservedGeneration records the value of .meta.generation
+                  at the point the controller last processed this object
+                format: int64
+                type: integer
+              outputs:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: Outputs contains the exported stack output variables resulting
+                  from a deployment.
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'Stack is the Schema for the stacks API. Deprecated: Note Stacks
+          from pulumi.com/v1alpha1 is deprecated in favor of pulumi.com/v1. It is completely
+          backward compatible. Users are strongly encouraged to switch to pulumi.com/v1.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StackSpec defines the desired state of Pulumi Stack being managed
+              by this operator.
+            properties:
+              accessTokenSecret:
+                description: '(optional) AccessTokenSecret is the name of a secret containing
+                  the PULUMI_ACCESS_TOKEN for Pulumi access. Deprecated: use EnvRefs
+                  with a "secret" entry with the key PULUMI_ACCESS_TOKEN instead.'
+                type: string
+              backend:
+                description: '(optional) Backend is an optional backend URL to use for
+                  all Pulumi operations.<br/> Examples:<br/> - Pulumi Service:              "https://app.pulumi.com"
+                  (default)<br/> - Self-managed Pulumi Service: "https://pulumi.acmecorp.com"
+                  <br/> - Local:                       "file://./einstein" <br/> - AWS:                         "s3://<my-pulumi-state-bucket>"
+                  <br/> - Azure:                       "azblob://<my-pulumi-state-bucket>"
+                  <br/> - GCP:                         "gs://<my-pulumi-state-bucket>"
+                  <br/> See: https://www.pulumi.com/docs/intro/concepts/state/'
+                type: string
+              branch:
+                description: (optional) Branch is the branch name to deploy, either
+                  the simple or fully qualified ref name, e.g. refs/heads/master. This
+                  is mutually exclusive with the Commit setting. Either value needs
+                  to be specified. When specified, the operator will periodically poll
+                  to check if the branch has any new commits. The frequency of the polling
+                  is configurable through ResyncFrequencySeconds, defaulting to every
+                  60 seconds.
+                type: string
+              commit:
+                description: (optional) Commit is the hash of the commit to deploy.
+                  If used, HEAD will be in detached mode. This is mutually exclusive
+                  with the Branch setting. Either value needs to be specified.
+                type: string
+              config:
+                additionalProperties:
+                  type: string
+                description: (optional) Config is the configuration for this stack,
+                  which can be optionally specified inline. If this is omitted, configuration
+                  is assumed to be checked in and taken from the source repository.
+                type: object
+              continueResyncOnCommitMatch:
+                description: (optional) ContinueResyncOnCommitMatch - when true - informs
+                  the operator to continue trying to update stacks even if the revision
+                  of the source matches. This might be useful in environments where
+                  Pulumi programs have dynamic elements for example, calls to internal
+                  APIs where GitOps style commit tracking is not sufficient.  Defaults
+                  to false, i.e. when a particular revision is successfully run, the
+                  operator will not attempt to rerun the program at that revision again.
+                type: boolean
+              destroyOnFinalize:
+                description: (optional) DestroyOnFinalize can be set to true to destroy
+                  the stack completely upon deletion of the CRD.
+                type: boolean
+              envRefs:
+                additionalProperties:
+                  description: ResourceRef identifies a resource from which information
+                    can be loaded. Environment variables, files on the filesystem, Kubernetes
+                    secrets and literal strings are currently supported.
+                  properties:
+                    env:
+                      description: Env selects an environment variable set on the operator
+                        process
+                      properties:
+                        name:
+                          description: Name of the environment variable
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    filesystem:
+                      description: FileSystem selects a file on the operator's file
+                        system
+                      properties:
+                        path:
+                          description: Path on the filesystem to use to load information
+                            from.
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    literal:
+                      description: LiteralRef refers to a literal value
+                      properties:
+                        value:
+                          description: Value to load
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    secret:
+                      description: SecretRef refers to a Kubernetes secret
+                      properties:
+                        key:
+                          description: Key within the secret to use.
+                          type: string
+                        name:
+                          description: Name of the secret
+                          type: string
+                        namespace:
+                          description: Namespace where the secret is stored. Deprecated;
+                            non-empty values will be considered invalid unless namespace
+                            isolation is disabled in the controller.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type:
+                      description: 'SelectorType is required and signifies the type
+                        of selector. Must be one of: Env, FS, Secret, Literal'
+                      type: string
+                  required:
+                  - type
+                  type: object
+                description: (optional) EnvRefs is an optional map containing environment
+                  variables as keys and stores descriptors to where the variables' values
+                  should be loaded from (one of literal, environment variable, file
+                  on the filesystem, or Kubernetes secret) as values.
+                type: object
+              envSecrets:
+                description: '(optional) SecretEnvs is an optional array of secret names
+                  containing environment variables to set. Deprecated: use EnvRefs instead.'
+                items:
+                  type: string
+                type: array
+              envs:
+                description: '(optional) Envs is an optional array of config maps containing
+                  environment variables to set. Deprecated: use EnvRefs instead.'
+                items:
+                  type: string
+                type: array
+              expectNoRefreshChanges:
+                description: (optional) ExpectNoRefreshChanges can be set to true if
+                  a stack is not expected to have changes during a refresh before the
+                  update is run. This could occur, for example, is a resource's state
+                  is changing outside of Pulumi (e.g., metadata, timestamps).
+                type: boolean
+              fluxSource:
+                description: FluxSource specifies how to fetch source code from a Flux
+                  source object.
+                properties:
+                  dir:
+                    description: Dir gives the subdirectory containing the Pulumi project
+                      (i.e., containing Pulumi.yaml) of interest, within the fetched
+                      source.
+                    type: string
+                  sourceRef:
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    type: object
+                required:
+                - sourceRef
+                type: object
+              gitAuth:
+                description: '(optional) GitAuth allows configuring git authentication
+                  options There are 3 different authentication options: * SSH private
+                  key (and its optional password) * Personal access token * Basic auth
+                  username and password Only one authentication mode will be considered
+                  if more than one option is specified, with ssh private key/password
+                  preferred first, then personal access token, and finally basic auth
+                  credentials.'
+                properties:
+                  accessToken:
+                    description: ResourceRef identifies a resource from which information
+                      can be loaded. Environment variables, files on the filesystem,
+                      Kubernetes secrets and literal strings are currently supported.
+                    properties:
+                      env:
+                        description: Env selects an environment variable set on the
+                          operator process
+                        properties:
+                          name:
+                            description: Name of the environment variable
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      filesystem:
+                        description: FileSystem selects a file on the operator's file
+                          system
+                        properties:
+                          path:
+                            description: Path on the filesystem to use to load information
+                              from.
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      literal:
+                        description: LiteralRef refers to a literal value
+                        properties:
+                          value:
+                            description: Value to load
+                            type: string
+                        required:
+                        - value
+                        type: object
+                      secret:
+                        description: SecretRef refers to a Kubernetes secret
+                        properties:
+                          key:
+                            description: Key within the secret to use.
+                            type: string
+                          name:
+                            description: Name of the secret
+                            type: string
+                          namespace:
+                            description: Namespace where the secret is stored. Deprecated;
+                              non-empty values will be considered invalid unless namespace
+                              isolation is disabled in the controller.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      type:
+                        description: 'SelectorType is required and signifies the type
+                          of selector. Must be one of: Env, FS, Secret, Literal'
+                        type: string
+                    required:
+                    - type
+                    type: object
+                  basicAuth:
+                    description: BasicAuth configures git authentication through basic
+                      auth — i.e. username and password. Both UserName and Password
+                      are required.
+                    properties:
+                      password:
+                        description: ResourceRef identifies a resource from which information
+                          can be loaded. Environment variables, files on the filesystem,
+                          Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on
+                              the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's
+                              file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information
+                                  from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Deprecated;
+                                  non-empty values will be considered invalid unless
+                                  namespace isolation is disabled in the controller.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the
+                              type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      userName:
+                        description: ResourceRef identifies a resource from which information
+                          can be loaded. Environment variables, files on the filesystem,
+                          Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on
+                              the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's
+                              file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information
+                                  from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Deprecated;
+                                  non-empty values will be considered invalid unless
+                                  namespace isolation is disabled in the controller.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the
+                              type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - password
+                    - userName
+                    type: object
+                  sshAuth:
+                    description: SSHAuth configures ssh-based auth for git authentication.
+                      SSHPrivateKey is required but password is optional.
+                    properties:
+                      password:
+                        description: ResourceRef identifies a resource from which information
+                          can be loaded. Environment variables, files on the filesystem,
+                          Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on
+                              the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's
+                              file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information
+                                  from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Deprecated;
+                                  non-empty values will be considered invalid unless
+                                  namespace isolation is disabled in the controller.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the
+                              type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      sshPrivateKey:
+                        description: ResourceRef identifies a resource from which information
+                          can be loaded. Environment variables, files on the filesystem,
+                          Kubernetes secrets and literal strings are currently supported.
+                        properties:
+                          env:
+                            description: Env selects an environment variable set on
+                              the operator process
+                            properties:
+                              name:
+                                description: Name of the environment variable
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          filesystem:
+                            description: FileSystem selects a file on the operator's
+                              file system
+                            properties:
+                              path:
+                                description: Path on the filesystem to use to load information
+                                  from.
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          literal:
+                            description: LiteralRef refers to a literal value
+                            properties:
+                              value:
+                                description: Value to load
+                                type: string
+                            required:
+                            - value
+                            type: object
+                          secret:
+                            description: SecretRef refers to a Kubernetes secret
+                            properties:
+                              key:
+                                description: Key within the secret to use.
+                                type: string
+                              name:
+                                description: Name of the secret
+                                type: string
+                              namespace:
+                                description: Namespace where the secret is stored. Deprecated;
+                                  non-empty values will be considered invalid unless
+                                  namespace isolation is disabled in the controller.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          type:
+                            description: 'SelectorType is required and signifies the
+                              type of selector. Must be one of: Env, FS, Secret, Literal'
+                            type: string
+                        required:
+                        - type
+                        type: object
+                    required:
+                    - sshPrivateKey
+                    type: object
+                type: object
+              gitAuthSecret:
+                description: '(optional) GitAuthSecret is the the name of a secret containing
+                  an authentication option for the git repository. There are 3 different
+                  authentication options: * Personal access token * SSH private key
+                  (and it''s optional password) * Basic auth username and password Only
+                  one authentication mode will be considered if more than one option
+                  is specified, with ssh private key/password preferred first, then
+                  personal access token, and finally basic auth credentials. Deprecated.
+                  Use GitAuth instead.'
+                type: string
+              programRef:
+                description: ProgramRef refers to a Program object, to be used as the
+                  source for the stack.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              projectRepo:
+                description: ProjectRepo is the git source control repository from which
+                  we fetch the project code and configuration.
+                type: string
+              refresh:
+                description: (optional) Refresh can be set to true to refresh the stack
+                  before it is updated.
+                type: boolean
+              repoDir:
+                description: (optional) RepoDir is the directory to work from in the
+                  project's source repository where Pulumi.yaml is located. It is used
+                  in case Pulumi.yaml is not in the project source root.
+                type: string
+              resyncFrequencySeconds:
+                description: (optional) ResyncFrequencySeconds when set to a non-zero
+                  value, triggers a resync of the stack at the specified frequency even
+                  if no changes to the custom-resource are detected. If branch tracking
+                  is enabled (branch is non-empty), commit polling will occur at this
+                  frequency. The minimal resync frequency supported is 60 seconds.
+                format: int64
+                type: integer
+              retryOnUpdateConflict:
+                description: (optional) RetryOnUpdateConflict issues a stack update
+                  retry reconciliation loop in the event that the update hits a HTTP
+                  409 conflict due to another update in progress. This is only recommended
+                  if you are sure that the stack updates are idempotent, and if you
+                  are willing to accept retry loops until all spawned retries succeed.
+                  This will also create a more populated, and randomized activity timeline
+                  for the stack in the Pulumi Service.
+                type: boolean
+              secrets:
+                additionalProperties:
+                  type: string
+                description: '(optional) Secrets is the secret configuration for this
+                  stack, which can be optionally specified inline. If this is omitted,
+                  secrets configuration is assumed to be checked in and taken from the
+                  source repository. Deprecated: use SecretRefs instead.'
+                type: object
+              secretsProvider:
+                description: '(optional) SecretsProvider is used to initialize a Stack
+                  with alternative encryption. Examples: - AWS:   "awskms:///arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34bc-56ef-1234567890ab?region=us-east-1"
+                  - Azure: "azurekeyvault://acmecorpvault.vault.azure.net/keys/mykeyname"
+                  - GCP:   "gcpkms://projects/MYPROJECT/locations/MYLOCATION/keyRings/MYKEYRING/cryptoKeys/MYKEY"
+                  - See: https://www.pulumi.com/docs/intro/concepts/secrets/#initializing-a-stack-with-alternative-encryption'
+                type: string
+              secretsRef:
+                additionalProperties:
+                  description: ResourceRef identifies a resource from which information
+                    can be loaded. Environment variables, files on the filesystem, Kubernetes
+                    secrets and literal strings are currently supported.
+                  properties:
+                    env:
+                      description: Env selects an environment variable set on the operator
+                        process
+                      properties:
+                        name:
+                          description: Name of the environment variable
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    filesystem:
+                      description: FileSystem selects a file on the operator's file
+                        system
+                      properties:
+                        path:
+                          description: Path on the filesystem to use to load information
+                            from.
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    literal:
+                      description: LiteralRef refers to a literal value
+                      properties:
+                        value:
+                          description: Value to load
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    secret:
+                      description: SecretRef refers to a Kubernetes secret
+                      properties:
+                        key:
+                          description: Key within the secret to use.
+                          type: string
+                        name:
+                          description: Name of the secret
+                          type: string
+                        namespace:
+                          description: Namespace where the secret is stored. Deprecated;
+                            non-empty values will be considered invalid unless namespace
+                            isolation is disabled in the controller.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type:
+                      description: 'SelectorType is required and signifies the type
+                        of selector. Must be one of: Env, FS, Secret, Literal'
+                      type: string
+                  required:
+                  - type
+                  type: object
+                description: (optional) SecretRefs is the secret configuration for this
+                  stack which can be specified through ResourceRef. If this is omitted,
+                  secrets configuration is assumed to be checked in and taken from the
+                  source repository.
+                type: object
+              stack:
+                description: Stack is the fully qualified name of the stack to deploy
+                  (<org>/<stack>).
+                type: string
+              useLocalStackOnly:
+                description: (optional) UseLocalStackOnly can be set to true to prevent
+                  the operator from creating stacks that do not exist in the tracking
+                  git repo. The default behavior is to create a stack if it doesn't
+                  exist.
+                type: boolean
+            required:
+            - stack
+            type: object
+          status:
+            description: StackStatus defines the observed state of Stack
+            properties:
+              lastUpdate:
+                description: LastUpdate contains details of the status of the last update.
+                properties:
+                  lastAttemptedCommit:
+                    description: Last commit attempted
+                    type: string
+                  lastResyncTime:
+                    description: LastResyncTime contains a timestamp for the last time
+                      a resync of the stack took place.
+                    format: date-time
+                    type: string
+                  lastSuccessfulCommit:
+                    description: Last commit successfully applied
+                    type: string
+                  permalink:
+                    description: Permalink is the Pulumi Console URL of the stack operation.
+                    type: string
+                  state:
+                    description: State is the state of the stack update - one of `succeeded`
+                      or `failed`
+                    type: string
+                type: object
+              outputs:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: Outputs contains the exported stack output variables resulting
+                  from a deployment.
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/deploy/helm/pulumi-operator/templates/_helpers.tpl
+++ b/deploy/helm/pulumi-operator/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pulumi-kubernetes-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "pulumi-kubernetes-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pulumi-kubernetes-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "pulumi-kubernetes-operator.labels" -}}
+helm.sh/chart: {{ include "pulumi-kubernetes-operator.chart" . }}
+{{ include "pulumi-kubernetes-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "pulumi-kubernetes-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pulumi-kubernetes-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "pulumi-kubernetes-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "pulumi-kubernetes-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/pulumi-operator/templates/deployment.yaml
+++ b/deploy/helm/pulumi-operator/templates/deployment.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ include "pulumi-kubernetes-operator.fullname" . }}
+  labels:
+  {{- include "pulumi-kubernetes-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.deploymentStrategy }}
+  selector:
+    matchLabels:
+    {{- include "pulumi-kubernetes-operator.selectorLabels" . | nindent 6 }}
+      app: {{ template "pulumi-kubernetes-operator.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app: {{ template "pulumi-kubernetes-operator.name" . }}
+        release: {{ .Release.Name }}
+      {{- include "pulumi-kubernetes-operator.selectorLabels" . | nindent 8 }}
+      {{- if .Values.podLabels }}
+        {{ toYaml .Values.podLabels | indent 8 }}
+      {{- end }}
+    spec:
+      containers:
+      {{- if .Values.extraSidecars }}
+      {{- toYaml .Values.extraSidecars  | nindent  8 }}
+      {{- end}}
+      - args:
+        {{- with .Values.controller.args }}
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
+        env:
+        {{- if .Values.extraEnv }}
+        {{- toYaml .Values.extraEnv  | nindent 10 }}
+        {{- end }}
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: {{ include "pulumi-kubernetes-operator.name" . }}
+        - name: GRACEFUL_SHUTDOWN_TIMEOUT_DURATION
+          value: {{ .Values.controller.gracefulShutdownTimeoutDuration }}
+        - name: MAX_CONCURRENT_RECONCILES
+          value: {{ .Values.controller.maxConcurrentReconciles | quote }}
+        - name: PULUMI_INFER_NAMESPACE
+          value: {{ .Values.controller.pulumiInferNamespace | quote }}
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ .Values.controller.kubernetesClusterDomain }}
+        image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:v{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: {{ .Chart.Name }}
+        {{- if .Values.securityContext }}
+        securityContext:
+        {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- end }}
+        {{- if .Values.resources }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        {{- end }}
+        volumeMounts:
+        {{- with .Values.extraVolumeMounts }}
+        {{- toYaml . | nindent 12 }}
+        {{- end }}
+        - mountPath: /tmp
+          name: tmp-dir
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "pulumi-kubernetes-operator.serviceAccountName" . }}
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      {{- if .Values.initContainers  }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+      {{- with .Values.initContainers }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- end }}
+      volumes:
+      {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      - emptyDir: {}
+        name: tmp-dir

--- a/deploy/helm/pulumi-operator/templates/role.yaml
+++ b/deploy/helm/pulumi-operator/templates/role.yaml
@@ -1,0 +1,90 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "pulumi-kubernetes-operator.fullname" . }}
+  labels:
+  {{- include "pulumi-kubernetes-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - pulumi-kubernetes-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - pulumi.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update

--- a/deploy/helm/pulumi-operator/templates/rolebinding.yaml
+++ b/deploy/helm/pulumi-operator/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "pulumi-kubernetes-operator.fullname" . }}
+  labels:
+  {{- include "pulumi-kubernetes-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "pulumi-kubernetes-operator.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "pulumi-kubernetes-operator.serviceAccountName" . }}
+    namespace: '{{ .Release.Namespace }}'

--- a/deploy/helm/pulumi-operator/templates/sa.yaml
+++ b/deploy/helm/pulumi-operator/templates/sa.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "pulumi-kubernetes-operator.fullname" . }}
+  labels:
+  {{- include "pulumi-kubernetes-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/pulumi-operator/templates/service.yaml
+++ b/deploy/helm/pulumi-operator/templates/service.yaml
@@ -1,0 +1,24 @@
+{{- if $.Values.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ print (include "pulumi-kubernetes-operator.fullname" .) "-metrics" }}
+  labels:
+    app: {{ template "pulumi-kubernetes-operator.name" . }}
+  annotations:
+{{ toYaml .Values.serviceMonitor.service.annotations | indent 4 }}
+spec:
+  type: {{ .Values.serviceMonitor.service.type }}
+  ports:
+    - port: 8383
+      targetPort: metrics
+      protocol: TCP
+      name: http-metrics
+    - port: 8686
+      targetPort: http
+      protocol: TCP
+      name: cr-metrics
+  selector:
+    app: {{ template "pulumi-kubernetes-operator.name" . }}
+    release: {{ .Release.Name }}
+  {{- end }}

--- a/deploy/helm/pulumi-operator/templates/servicemonitor.yaml
+++ b/deploy/helm/pulumi-operator/templates/servicemonitor.yaml
@@ -1,0 +1,45 @@
+{{- if $.Values.serviceMonitor.enabled }}
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+{{- if .Values.serviceMonitor.labels }}
+  labels:
+{{ toYaml .Values.serviceMonitor.labels | indent 4}}
+{{- end }}
+  name: {{ template "pulumi-kubernetes-operator.fullname" . }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - targetPort: 8383
+{{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.serviceMonitor.telemetryPath }}
+    path: {{ .Values.serviceMonitor.telemetryPath }}
+{{- end }}
+{{- if .Values.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
+{{- end }}
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+{{- end }}
+  jobLabel: {{ template "pulumi-kubernetes-operator.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "pulumi-kubernetes-operator.name" . }}
+      release: {{ .Release.Name }}
+{{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+{{- range .Values.serviceMonitor.targetLabels }}
+    - {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/pulumi-operator/values.yaml
+++ b/deploy/helm/pulumi-operator/values.yaml
@@ -1,0 +1,128 @@
+# -- Specifies the strategy used to replace old Pods by new ones, default: `RollingUpdate`
+deploymentStrategy: ""
+
+# -- Specifies the replica count for the deployment
+replicaCount: 1
+
+image:
+  # -- The image registry to pull from
+  registry: docker.io
+  # -- The image repository to pull from
+  repository: pulumi/pulumi-kubernetes-operator
+  # -- The image pull policy
+  pullPolicy: IfNotPresent
+  # -- The image tag to pull, default: `Chart.appVersion`
+  tag: ""
+
+controller:
+  # -- Graceful shutdown timeout duration, default: `5m`
+  gracefulShutdownTimeoutDuration: 5m
+  # -- Max concurrent reconciles, default: `10`
+  maxConcurrentReconciles: "10"
+  # -- Pulumi infer namespace, default: `1`
+  pulumiInferNamespace: "1"
+  # -- Kubernetes Cluster Domain, default: `cluster.local`
+  kubernetesClusterDomain: cluster.local
+
+  # -- List of arguments to pass to the operator
+  args:
+    - --zap-level=error
+    - --zap-time-encoding=iso8601
+
+# -- Extra Environments to be passed to the operator
+extraEnv: []
+
+# -- The image pull secrets
+imagePullSecrets: ""
+
+# -- Provide a name in place of pulumi-kubernetes-operator
+nameOverride: ""
+# -- String to fully override "pulumi-kubernetes-operator.fullname"
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  # -- Create service account
+  create: true
+  # Annotations to add to the service account
+  # -- Additional ServiceAccount annotations
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  # -- Service account name to use, when empty will be set to created account if
+  name: ""
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Deployment annotations
+deploymentAnnotations: {}
+
+# -- Pod Security Context see [values.yaml](values.yaml)
+podSecurityContext:
+  # -- pulumi-kubernetes-operator group is 1000
+  fsGroup: 1000
+  # -- pulumi-kubernetes-operator user is 1000
+  runAsUser: 1000
+
+# -- Security Context see [values.yaml](values.yaml)
+securityContext:
+  privileged: false
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  # readOnlyRootFilesystem: true
+  runAsGroup: 10003
+  # runAsUser: 10003
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop:
+      - ALL
+
+# -- containers which are run before the app containers are started
+initContainers: []
+
+# -- CPU/Memory resource requests/limits
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 500m
+    memory: 5123Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+# -- Node selector
+nodeSelector: {}
+
+# -- Toleration labels for pod assignment
+tolerations: []
+
+# -- The affinity constraint
+affinity: {}
+
+# -- Extra Volumes for the pod
+extraVolumes:
+# - name: pv-claim
+#   persistentVolumeClaim:
+#     claimName: task-pv-volume
+# - name: example
+#   configMap:
+#     name: example
+
+# -- Extra Volume Mounts for the pulumi-kubernetes-operator pod
+extraVolumeMounts:
+# - name: test
+#   mountPath: /test
+
+# -- Labels to add to the pulumi-kubernetes-operator pod. default: {}
+podLabels: {}
+
+# -- You can configure extra sidecars containers to run alongside the pulumi-kubernetes-operator pod. default: []
+extraSidecars: []
+#  - name: sidecar-example
+#    image: busybox
+#    command: ["/bin/sh", "-c", "echo hello from sidecar"]

--- a/deploy/helm/pulumi-operator/values.yaml
+++ b/deploy/helm/pulumi-operator/values.yaml
@@ -126,3 +126,20 @@ extraSidecars: []
 #  - name: sidecar-example
 #    image: busybox
 #    command: ["/bin/sh", "-c", "echo hello from sidecar"]
+
+serviceMonitor:
+  # -- When set true then use a ServiceMonitor to configure scraping
+  enabled: false
+  # Set the namespace the ServiceMonitor should be deployed
+  # namespace: monitoring
+  # Set how frequently Prometheus should scrape
+  # interval: 30s
+  # Set path to minecraft-exporter telemtery-path
+  # telemetryPath: /metrics
+  # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+  # labels:
+  # Set timeout for scrape
+  # timeout: 10s
+  # Set of labels to transfer on the Kubernetes Service onto the target.
+  # targetLabels: []
+  # metricRelabelings: []


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Hi,

this PR adds the creation of Helm chart for the Pulumi operator.

The helm chart can be deployed in two ways:

- Via Helm Repo (gh-page in this repo)
- or signed OCI artefact (pushed to ghcr in this Organisation)

It uses:

- Trivy to test for misconfiguration
- chart-testing to lint the chart
- chart-releaser to release the chart
- cosign to sign the OCI helm chart

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
