### PR TITLE
Add pprof (profiling) HTTP endpoint

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"runtime"
 	"strings"
@@ -69,7 +71,15 @@ func main() {
 	// controller-runtime)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
+	pprofBindAddress := pflag.CommandLine.String("debug-pprof-addr", "", "address to which to bind a pprof endpoint")
+
 	pflag.Parse()
+
+	if *pprofBindAddress != "" {
+		go func() {
+			log.Info(http.ListenAndServe(*pprofBindAddress, nil).Error())
+		}()
+	}
 
 	// Use a zap logr.Logger implementation. If none of the zap
 	// flags are configured (or if the zap flag set is not being


### PR DESCRIPTION
It's handy to have pprof available to use on running systems. This PR adds a flag `--debug-pprof-addr` to the operator, which will start a pprof endpoint if the flag is supplied.
