### PR TITLE
stack-examples: Fix projectRepo ref example

### DIFF
--- a/stack-examples/yaml/nginx_k8s_stack.yaml
+++ b/stack-examples/yaml/nginx_k8s_stack.yaml
@@ -17,7 +17,8 @@ spec:
       secret:
         name: pulumi-api-secret
         key: accessToken
-  stack: <ACCOUNT_NAME>/nginx/dev
-  projectRepo: https://github.com/stevesloka/pulumi-nginx
+  stack: <ACCOUNT_NAME>/k8s-nginx/dev
+  projectRepo: https://github.com/pulumi/examples
+  repoDir: /kubernetes-ts-nginx
   branch: "refs/heads/master"
   destroyOnFinalize: true

--- a/stack-examples/yaml/nginx_k8s_stack.yaml
+++ b/stack-examples/yaml/nginx_k8s_stack.yaml
@@ -18,6 +18,6 @@ spec:
         name: pulumi-api-secret
         key: accessToken
   stack: <ACCOUNT_NAME>/nginx/dev
-  projectRepo: https://github.com/metral/pulumi-nginx
+  projectRepo: https://github.com/stevesloka/pulumi-nginx
   branch: "refs/heads/master"
   destroyOnFinalize: true

--- a/stack-examples/yaml/s3backend/nginx_k8s_stack.yaml
+++ b/stack-examples/yaml/s3backend/nginx_k8s_stack.yaml
@@ -36,6 +36,7 @@ spec:
         name: aws-creds-secret
         key: AWS_SESSION_TOKEN
   stack: "s3backend.nginx.dev"
-  projectRepo: https://github.com/metral/pulumi-nginx
+  projectRepo: https://github.com/pulumi/examples
+  repoDir: /kubernetes-ts-nginx
   branch: "refs/heads/master"
   destroyOnFinalize: true


### PR DESCRIPTION
### Proposed changes

When following the example yaml implementation (https://github.com/pulumi/pulumi-kubernetes-operator/blob/master/docs/create-stacks-using-kubectl.md#nginx-deployment) it uses the projectRepo (https://github.com/metral/pulumi-nginx) which has a sample nginx deployment and is very out of date.

When running this example, I ended up with the following errors in the operator:
```
{"level":"error","ts":1671481232.6940339,"logger":"controller_stack","msg":"Failed to update Stack","Request.Namespace":"pulumi","Request.Name":"nginx-k8s-stack","Stack.Name":"stevesloka/nginx/dev","error":"installing project dependencies: exit status 1","stacktrace":"github.com/pulumi/pulumi-kubernetes-operator/pkg/controller/stack.(*ReconcileStack).Reconcile\n\t/Users/stevesloka/godev/src/github.com/pulumi/pulumi-kubernetes-operator/pkg/controller/stack/stack_controller.go:462\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/Users/stevesloka/godev/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:298\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/Users/stevesloka/godev/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:253\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/Users/stevesloka/godev/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.0/pkg/internal/controller/controller.go:214"}
```

It turns out that the deps are so old that `npm install` failed which matches the error (e.g. `exit 1`), but wasn't quite apparent.

I forked the repo and updated my deps and it works fine now: https://github.com/stevesloka/pulumi-nginx

Maybe we should move this to pulumi/examples so it's better maintained?

### Related issues (optional)

Fixes #385

Signed-off-by: Steve Sloka <steve@pulumi.com>

