### PR TITLE
flux-source: Add skipInstallDependencies flag

### DIFF
--- a/deploy/crds/pulumi.com_stacks.yaml
+++ b/deploy/crds/pulumi.com_stacks.yaml
@@ -189,6 +189,10 @@ spec:
                       project (i.e., containing Pulumi.yaml) of interest, within the
                       fetched source.
                     type: string
+                  skipInstallDependencies:
+                    description: SkipInstallDependencies can be set to true to skip
+                      automatically installing dependencies.
+                    type: boolean
                   sourceRef:
                     properties:
                       apiVersion:
@@ -965,6 +969,10 @@ spec:
                       project (i.e., containing Pulumi.yaml) of interest, within the
                       fetched source.
                     type: string
+                  skipInstallDependencies:
+                    description: SkipInstallDependencies can be set to true to skip
+                      automatically installing dependencies.
+                    type: boolean
                   sourceRef:
                     properties:
                       apiVersion:

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -472,6 +472,13 @@ FluxSource specifies how to fetch source code from a Flux source object.
           Dir gives the subdirectory containing the Pulumi project (i.e., containing Pulumi.yaml) of interest, within the fetched source.<br/>
         </td>
         <td>false</td>
+      </tr><tr>
+        <td><b>skipInstallDependencies</b></td>
+        <td>boolean</td>
+        <td>
+          SkipInstallDependencies can be set to true to skip automatically installing dependencies.<br/>
+        </td>
+        <td>false</td>
       </tr></tbody>
 </table>
 
@@ -2356,6 +2363,13 @@ FluxSource specifies how to fetch source code from a Flux source object.
         <td>string</td>
         <td>
           Dir gives the subdirectory containing the Pulumi project (i.e., containing Pulumi.yaml) of interest, within the fetched source.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>skipInstallDependencies</b></td>
+        <td>boolean</td>
+        <td>
+          SkipInstallDependencies can be set to true to skip automatically installing dependencies.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/pkg/apis/pulumi/shared/stack_types.go
+++ b/pkg/apis/pulumi/shared/stack_types.go
@@ -187,6 +187,9 @@ type FluxSource struct {
 	// interest, within the fetched source.
 	// +optional
 	Dir string `json:"dir,omitempty"`
+
+	// SkipInstallDependencies can be set to true to skip automatically installing dependencies.
+	SkipInstallDependencies bool `json:"skipInstallDependencies,omitempty"`
 }
 
 type FluxSourceReference struct {

--- a/test/flux_source_test.go
+++ b/test/flux_source_test.go
@@ -244,6 +244,7 @@ var _ = Describe("Flux source integration", func() {
 							Kind:       "Fake",
 							Name:       source.GetName(),
 						},
+						SkipInstallDependencies: true,
 					},
 				},
 			}


### PR DESCRIPTION
### Proposed changes

Adds a skipInstallDependencies flag to the flux source integration which disables the automatic dependency installation.

### Related issues (optional)

Fixes #374
