### PR TITLE
Put GITHUB_TOKEN in env to mitigate API throttling

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -8,6 +8,7 @@ on:
       - CHANGELOG.md
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   operator-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
       - v*.*.*
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   operator-int-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-acceptance-tests.yaml
+++ b/.github/workflows/run-acceptance-tests.yaml
@@ -8,6 +8,7 @@ on:
       - master
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   comment-notification:
     if: github.event_name == 'repository_dispatch'


### PR DESCRIPTION
GitHub has quite strict limits on API requests if you are an unauthenticated user, which the tests can run into since they download Pulumi plugins from GitHub. In the context of GitHub Actions, there is an access token available, which will give elevated API quotas. Actions can use it by default, but it needs to be made available in the environment for it to be in effect in tests.

Hence: add an environment entry for GITHUB_TOKEN to any workflow that runs the tests.
