### PR TITLE
Added lastUpdate state update to ensure that synchronized commits display a succeeded status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
   image of the same version, fixing [issue
   #411](https://github.com/pulumi/pulumi-kubernetes-operator/issues/411)
   [#422](https://github.com/pulumi/pulumi-kubernetes-operator/pull/422)
+- Added lastUpdate state update to ensure that synchronized commits display a succeeded status.
+  [#429](https://github.com/pulumi/pulumi-kubernetes-operator/pull/429)
 
 ## 1.11.1 (2023-02-08)
 

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -628,6 +628,11 @@ func (r *ReconcileStack) Reconcile(ctx context.Context, request reconcile.Reques
 				reqLogger.Info("Commit hash unchanged. Will poll again.", "pollFrequencySeconds", resyncFreqSeconds)
 				// Reconcile every resyncFreqSeconds to check for new commits to the branch.
 				instance.Status.MarkReadyCondition() // FIXME: should this reflect the previous update state?
+				// Ensure lastUpdate state is updated if previous sync failure occurred
+				if instance.Status.LastUpdate.State != shared.SucceededStackStateMessage {
+					instance.Status.LastUpdate.State = shared.SucceededStackStateMessage
+					instance.Status.LastUpdate.LastResyncTime = metav1.Now()
+				}
 				return reconcile.Result{RequeueAfter: time.Duration(resyncFreqSeconds) * time.Second}, nil
 			}
 
@@ -644,6 +649,11 @@ func (r *ReconcileStack) Reconcile(ctx context.Context, request reconcile.Reques
 				reqLogger.Info("Commit hash unchanged. Will poll again.", "pollFrequencySeconds", resyncFreqSeconds)
 				// Reconcile every resyncFreqSeconds to check for new commits to the branch.
 				instance.Status.MarkReadyCondition() // FIXME: should this reflect the previous update state?
+				// Ensure lastUpdate state is updated if previous sync failure occurred
+				if instance.Status.LastUpdate.State != shared.SucceededStackStateMessage {
+					instance.Status.LastUpdate.State = shared.SucceededStackStateMessage
+					instance.Status.LastUpdate.LastResyncTime = metav1.Now()
+				}
 				return reconcile.Result{RequeueAfter: time.Duration(resyncFreqSeconds) * time.Second}, nil
 			}
 
@@ -659,6 +669,11 @@ func (r *ReconcileStack) Reconcile(ctx context.Context, request reconcile.Reques
 				reqLogger.Info("Commit hash unchanged. Will poll again.", "pollFrequencySeconds", resyncFreqSeconds)
 				// Reconcile every resyncFreqSeconds to check for new commits to the branch.
 				instance.Status.MarkReadyCondition() // FIXME: should this reflect the previous update state?
+				// Ensure lastUpdate state is updated if previous sync failure occurred
+				if instance.Status.LastUpdate.State != shared.SucceededStackStateMessage {
+					instance.Status.LastUpdate.State = shared.SucceededStackStateMessage
+					instance.Status.LastUpdate.LastResyncTime = metav1.Now()
+				}
 				return reconcile.Result{RequeueAfter: time.Duration(resyncFreqSeconds) * time.Second}, nil
 			}
 


### PR DESCRIPTION
### Proposed changes
The proposed changes add `lastUpdate` state changes when a commit ID is already synchronized, but the stack is not already marked as `succeeded`.

### Related issues (optional)
https://github.com/pulumi/pulumi-kubernetes-operator/issues/428
