### PR TITLE
Prepare manifests for v1.11.5 release

### DIFF
--- a/deploy/deploy-operator-cs/MyStack.cs
+++ b/deploy/deploy-operator-cs/MyStack.cs
@@ -7,8 +7,8 @@ using Pulumi.Kubernetes.Types.Inputs.Rbac.V1;
 
 class MyStack : Stack
 {
-    public const string DefaultCRDVersion = "v1.11.0";
-    public const string DefaultOperatorVersion = "v1.11.0";
+    public const string DefaultCRDVersion = "v1.11.5";
+    public const string DefaultOperatorVersion = "v1.11.5";
 
     public MyStack()
     {

--- a/deploy/deploy-operator-go/main.go
+++ b/deploy/deploy-operator-go/main.go
@@ -12,8 +12,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
-const DefaultCRDVersion = "v1.11.0"
-const DefaultOperatorVersion = "v1.11.0"
+const DefaultCRDVersion = "v1.11.5"
+const DefaultOperatorVersion = "v1.11.5"
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {

--- a/deploy/deploy-operator-py/__main__.py
+++ b/deploy/deploy-operator-py/__main__.py
@@ -2,8 +2,8 @@ import pulumi
 from pulumi.resource import ResourceOptions
 import pulumi_kubernetes as kubernetes
 
-DEFAULT_CRD_VERSION = "v1.11.0"
-DEFAULT_OPERATOR_VERSION = "v1.11.0"
+DEFAULT_CRD_VERSION = "v1.11.5"
+DEFAULT_OPERATOR_VERSION = "v1.11.5"
 
 conf = pulumi.Config()
 namespace = conf.get("namespace", "default")

--- a/deploy/deploy-operator-ts/index.ts
+++ b/deploy/deploy-operator-ts/index.ts
@@ -1,8 +1,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as kubernetes from "@pulumi/kubernetes";
 
-const defaultCRDVersion = "v1.11.0";
-const defaultOperatorVersion = "v1.11.0";
+const defaultCRDVersion = "v1.11.5";
+const defaultOperatorVersion = "v1.11.5";
 
 const config = new pulumi.Config();
 const deployNamespace = config.get("namespace") || 'default';

--- a/deploy/yaml/operator.yaml
+++ b/deploy/yaml/operator.yaml
@@ -20,7 +20,7 @@ spec:
           emptyDir: {}
       containers:
         - name: pulumi-kubernetes-operator
-          image: pulumi/pulumi-kubernetes-operator:v1.11.0
+          image: pulumi/pulumi-kubernetes-operator:v1.11.5
           args:
             - "--zap-level=error"
             - "--zap-time-encoding=iso8601"


### PR DESCRIPTION
### Proposed changes

Update image references for the upcoming v1.11.5 release.

This is to prep #438 for release. Upon digging, it looks like image versions need to be manually updated for our manifests.
