### PR TITLE
Increase timeout for stack state reconciliation in tests to 60s

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -164,7 +164,7 @@ func resetWaitForStack() {
 // internalWaitForStackState refetches the given stack, until its .lastUpdated.state field matches
 // the one given. NB it fetches into the pointer given, so mutates the struct it's pointing at.
 func internalWaitForStackState(stack *pulumiv1.Stack, state shared.StackUpdateStateMessage, optionalTimeout ...string) {
-	timeout := "30s"
+	timeout := "60s"
 	if len(optionalTimeout) > 0 {
 		timeout = optionalTimeout[0]
 	}


### PR DESCRIPTION
Some reconcilations can take around 30s to occur in our tests, and could cause flakey-ness if our timeout is hit first.