### PR TITLE
Use digest field for Flux source artifact if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (unreleased)
+- Use digest field for Flux source artifact if present [#459](https://github.com/pulumi/pulumi-kubernetes-operator/pull/459)
 
 ## 1.12.1 (2023-05-19)
 - Update to [Pulumi SDK v3.68.0](https://github.com/pulumi/pulumi/releases/tag/v3.68.0) and the base

--- a/pkg/controller/stack/flux_test.go
+++ b/pkg/controller/stack/flux_test.go
@@ -1,0 +1,162 @@
+// Copyright 2022, Pulumi Corporation.  All rights reserved.
+
+package stack
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// yamlToUnstructured is a helper to convert a YAML string to an unstructured object.
+func yamlToUnstructured(t *testing.T, yml string) unstructured.Unstructured {
+	t.Helper()
+	m := make(map[string]interface{})
+	err := yaml.Unmarshal([]byte(yml), &m)
+	if err != nil {
+		t.Fatalf("error parsing yaml: %v", err)
+	}
+	return unstructured.Unstructured{Object: m}
+}
+
+func TestGetArtifactField(t *testing.T) {
+	tests := []struct {
+		name, source, field, want string
+		wantErr                   bool
+	}{
+		{
+			name: "Get valid field - happy path",
+			source: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+    name: pulumi-git-repo
+spec:
+    interval: 1m
+status:
+    artifact:
+        url: http://example.com
+        revision: "1234567890"
+        checksum: "123abcdef"`,
+			field:   "checksum",
+			want:    "123abcdef",
+			wantErr: false,
+		},
+		{
+			name: "Expect error for non-existent field",
+			source: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+    name: pulumi-git-repo
+spec:
+    interval: 1m
+status:
+    artifact:
+        url: http://example.com
+        revision: "1234567890"
+        checksum: "123abcdef"`,
+			field:   "unknown",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			obj := yamlToUnstructured(t, tc.source)
+			got, err := getArtifactField(obj, tc.field)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("getField() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("getField() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestChecksumOrDigest(t *testing.T) {
+	tests := []struct {
+		name, source, want string
+		wantErr            bool
+	}{
+		{
+			name: "Get checksum field - happy path",
+			source: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+    name: pulumi-git-repo
+spec:
+    interval: 1m
+status:
+    artifact:
+        url: http://example.com
+        revision: "1234567890"
+        checksum: "123abcdef"`,
+			want:    "123abcdef",
+			wantErr: false,
+		},
+		{
+			name: "Get digest field - happy path",
+			source: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+    name: pulumi-git-repo
+spec:
+    interval: 1m
+status:
+    artifact:
+        url: http://example.com
+        revision: "1234567890"
+        digest: "sha256:123abcdef"`,
+			want:    "sha256:123abcdef",
+			wantErr: false,
+		},
+		{
+			name: "Get digest field when both digest and checksum present",
+			source: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+    name: pulumi-git-repo
+spec:
+    interval: 1m
+status:
+    artifact:
+        url: http://example.com
+        revision: "1234567890"
+        digest: "sha256:123abcdef"
+        checksum: "1234567890"`,
+			want:    "sha256:123abcdef",
+			wantErr: false,
+		},
+		{
+			name: "Error if neither digest nor checksum present",
+			source: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+    name: pulumi-git-repo
+spec:
+    interval: 1m
+status:
+    artifact:
+        url: http://example.com
+        revision: "1234567890"`,
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			obj := yamlToUnstructured(t, tc.source)
+			got, err := checksumOrDigest(obj)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("checksumOrDigest() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+			if got != tc.want {
+				t.Errorf("checksumOrDigest() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/stack/flux_test.go
+++ b/pkg/controller/stack/flux_test.go
@@ -109,7 +109,7 @@ status:
         url: http://example.com
         revision: "1234567890"
         digest: "sha256:123abcdef"`,
-			want:    "sha256:123abcdef",
+			want:    "123abcdef",
 			wantErr: false,
 		},
 		{
@@ -126,7 +126,7 @@ status:
         revision: "1234567890"
         digest: "sha256:123abcdef"
         checksum: "1234567890"`,
-			want:    "sha256:123abcdef",
+			want:    "123abcdef",
 			wantErr: false,
 		},
 		{

--- a/test/flux_source_test.go
+++ b/test/flux_source_test.go
@@ -219,7 +219,7 @@ var _ = Describe("Flux source integration", func() {
 					"path":     "irrelevant",
 					"url":      artifactURL,
 					"revision": artifactRevision,
-					"checksum": artifactChecksum,
+					"digest":   "sha256:" + artifactChecksum,
 				},
 			}
 			source.SetKind("Fake")
@@ -288,7 +288,7 @@ var _ = Describe("Flux source integration", func() {
 						"path":     "irrelevant",
 						"url":      artifactURL,
 						"revision": newArtifactRevision,
-						"checksum": artifactChecksum,
+						"digest":   "sha256:" + artifactChecksum,
 					},
 				}
 				unstructured.SetNestedMap(source.Object, sourceStatus, "status")
@@ -355,7 +355,7 @@ var _ = Describe("Flux source integration", func() {
 					"path":     "irrelevant",
 					"url":      artifactURL,
 					"revision": newArtifactRevision,
-					"checksum": artifactChecksum,
+					"digest":   "sha256:" + artifactChecksum,
 				}
 				unstructured.SetNestedMap(source.Object, artifact, "status", "artifact")
 				Expect(k8sClient.Status().Update(context.TODO(), source)).To(Succeed())
@@ -366,12 +366,12 @@ var _ = Describe("Flux source integration", func() {
 			})
 		})
 
-		When("the checksum is wrong", func() {
+		When("the digest is wrong", func() {
 			BeforeEach(func() {
-				unstructured.SetNestedField(source.Object, "not-the-right-checksum",
-					"status", "artifact", "checksum")
+				unstructured.SetNestedField(source.Object, "sha256:not-the-right-digest",
+					"status", "artifact", "digest")
 				Expect(k8sClient.Status().Update(context.TODO(), source)).To(Succeed())
-				stack.Name = "source-bad-checksum"
+				stack.Name = "source-bad-digest"
 			})
 
 			It("rejects the tarball and fails with a retry", func() {

--- a/test/testdata/fluxsource_crd.yaml
+++ b/test/testdata/fluxsource_crd.yaml
@@ -38,8 +38,9 @@ spec:
                 description: Artifact represents the output of the last successful
                   Bucket sync.
                 properties:
-                  checksum:
-                    description: Checksum is the SHA256 checksum of the artifact.
+                  digest:
+                    description: Digest is the digest of the file in the form of '<algorithm>:<checksum>'.
+                    pattern: ^[a-z0-9]+(?:[.+_-][a-z0-9]+)*:[a-zA-Z0-9=_-]+$
                     type: string
                   lastUpdateTime:
                     description: LastUpdateTime is the timestamp corresponding to


### PR DESCRIPTION
### Proposed changes
v1 of the Flux source artifact type removed the `.status.artifact.checksum` field in favor of `.status.artifact.digest`. This PR adds logic to use the `digest` field with a fallback for `checksum`.

Note: we need to normalize the digest field since the current verifier function only accepts a hash, instead of the digest format (`<algorithm>:<hash>"`). We'd have to update github.com/fluxcd/pkg/http/fetch to at least v0.4.0 or higher to remove this normalization. However, upgrading our dependencies isn't as simple as `go get -u ./... && go mod tidy` since our dependencies are relatively old and the project will need to be refactored.

### Related issues (optional)
Fixes: #457 
