### PR TITLE
indentation fix for adding new volumes and volume mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (unreleased)
+- Changed indentation in deploy/helm/pulumi-operator/templates/deployment.yaml for volumes and volumeMounts.
 
 ## 1.13.0 (2023-08-04)
 - Use digest field for Flux source artifact if present [#459](https://github.com/pulumi/pulumi-kubernetes-operator/pull/459)

--- a/deploy/helm/pulumi-operator/Chart.yaml
+++ b/deploy/helm/pulumi-operator/Chart.yaml
@@ -9,7 +9,7 @@ icon: https://www.pulumi.com/logos/brand/twitter-card.png
 
 type: application
 
-version: 0.2.0
+version: 0.3.0
 appVersion: 1.13.0
 
 keywords:
@@ -25,7 +25,7 @@ maintainers:
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - update to v1.13.0
+    - indentation fix for adding new volumes and volume mounts  (#104)
   artifacthub.io/images: |
     - name: pulumi-kubernetes-operator
       image: docker.io/pulumi-kubernetes-operator:v1.13.0

--- a/deploy/helm/pulumi-operator/README.md
+++ b/deploy/helm/pulumi-operator/README.md
@@ -1,6 +1,6 @@
 # node-red ⚙
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 1.13.0](https://img.shields.io/badge/AppVersion-1.13.0-informational?style=for-the-badge)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 1.13.0](https://img.shields.io/badge/AppVersion-1.13.0-informational?style=for-the-badge)
 
 ## Description 📜
 
@@ -11,7 +11,7 @@ A Helm chart for the Pulumi Kubernetes Operator
 To install the chart using the OCI artifact, run:
 
 ```bash
-helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator --version 0.2.0
+helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator --version 0.3.0
 ```
 
 ## Usage
@@ -27,7 +27,7 @@ helm repo update
 To install the chart with the release name `pulumi-kubernetes-operator` run:
 
 ```bash
-helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --version 0.2.0
+helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --version 0.3.0
 ```
 
 After a few seconds, the `pulumi-kubernetes-operator` should be running.

--- a/deploy/helm/pulumi-operator/templates/deployment.yaml
+++ b/deploy/helm/pulumi-operator/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
         {{- end }}
         volumeMounts:
         {{- with .Values.extraVolumeMounts }}
-        {{- toYaml . | nindent 12 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         - mountPath: /tmp
           name: tmp-dir
@@ -107,7 +107,7 @@ spec:
       {{- end }}
       volumes:
       {{- with .Values.extraVolumes }}
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}
       - emptyDir: {}
         name: tmp-dir


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

Adding new volumes to pulumi-kubernetes-operator failed due to incorrect indentation in deployment.yaml template for volumeMounts and volumes.


### Proposed changes
Changed indentation in deployment.yaml file. 

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
