### PR TITLE
Use semver tag for goreleaser master builds

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.19.x
-      # Get the last semver tag and use it as the version for the release. This is required as we releaser both Helm charts and the operator
+      # Get the last semver tag and use it as the version for the release. This is required as we release both Helm charts and the operator
       # within this repository.
       - name: Get last semver tag
         id: semver

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "rquitales/fix-action"
     paths-ignore:
       - CHANGELOG.md
 env:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -24,6 +24,11 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.19.x
+      # Get the last semver tag and use it as the version for the release. This is required as we releaser both Helm charts and the operator
+      # within this repository.
+      - name: Get last semver tag
+        id: semver
+        run: echo "GORELEASER_CURRENT_TAG=$(git describe --tags --match "v*" --abbrev=0)" >> $GITHUB_ENV
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "master"
-      - "rquitales/fix-action"
     paths-ignore:
       - CHANGELOG.md
 env:


### PR DESCRIPTION
This fixes the build failures caused when the last tag fetched is for the Helm chart, and is in the format `pulumi-kubernetes-operator-[0-9].[0-9].[0-9]` instead of a semver tag.

Example failed run: https://github.com/pulumi/pulumi-kubernetes-operator/actions/runs/6201701807
This PR added and removed this branch as well to trigger this workflow to ensure that this fix works as expected before being merged. Validation run: https://github.com/pulumi/pulumi-kubernetes-operator/actions/runs/6238681684/job/16935042636