### PR TITLE
Set terminationGracePeriodSeconds for HelmCharts

### DIFF
--- a/deploy/helm/pulumi-operator/Chart.yaml
+++ b/deploy/helm/pulumi-operator/Chart.yaml
@@ -9,7 +9,7 @@ icon: https://www.pulumi.com/logos/brand/twitter-card.png
 
 type: application
 
-version: 0.4.0
+version: 0.5.0
 appVersion: 1.14.0
 
 keywords:
@@ -25,7 +25,7 @@ maintainers:
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - v1.14.0 release
+    - set terminationGracePeriodSeconds for HelmCharts (#520)
   artifacthub.io/images: |
     - name: pulumi-kubernetes-operator
       image: docker.io/pulumi-kubernetes-operator:v1.14.0

--- a/deploy/helm/pulumi-operator/README.md
+++ b/deploy/helm/pulumi-operator/README.md
@@ -82,7 +82,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | podSecurityContext.fsGroup | int | `1000` | pulumi-kubernetes-operator group is 1000 |
 | podSecurityContext.runAsUser | int | `1000` | pulumi-kubernetes-operator user is 1000 |
 | replicaCount | int | `1` | Specifies the replica count for the deployment |
-| terminationGracePeriodSeconds | int | `` | Specifies termination grace period |
+| terminationGracePeriodSeconds | int | `300` | Specifies termination grace period |
 | resources | object | `{"limits":{"cpu":"500m","memory":"5123Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | CPU/Memory resource requests/limits |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"runAsGroup":10003,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security Context see [values.yaml](values.yaml) |
 | serviceAccount.annotations | object | `{}` | Additional ServiceAccount annotations |

--- a/deploy/helm/pulumi-operator/README.md
+++ b/deploy/helm/pulumi-operator/README.md
@@ -1,6 +1,6 @@
 # node-red ⚙
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 1.13.0](https://img.shields.io/badge/AppVersion-1.13.0-informational?style=for-the-badge)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 1.14.0](https://img.shields.io/badge/AppVersion-1.14.0-informational?style=for-the-badge) 
 
 ## Description 📜
 
@@ -11,7 +11,7 @@ A Helm chart for the Pulumi Kubernetes Operator
 To install the chart using the OCI artifact, run:
 
 ```bash
-helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator --version 0.3.0
+helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator --version 0.5.0
 ```
 
 ## Usage
@@ -27,7 +27,7 @@ helm repo update
 To install the chart with the release name `pulumi-kubernetes-operator` run:
 
 ```bash
-helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --version 0.3.0
+helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --version 0.5.0
 ```
 
 After a few seconds, the `pulumi-kubernetes-operator` should be running.
@@ -82,13 +82,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | podSecurityContext.fsGroup | int | `1000` | pulumi-kubernetes-operator group is 1000 |
 | podSecurityContext.runAsUser | int | `1000` | pulumi-kubernetes-operator user is 1000 |
 | replicaCount | int | `1` | Specifies the replica count for the deployment |
-| terminationGracePeriodSeconds | int | `300` | Specifies termination grace period |
 | resources | object | `{"limits":{"cpu":"500m","memory":"5123Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | CPU/Memory resource requests/limits |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"runAsGroup":10003,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security Context see [values.yaml](values.yaml) |
 | serviceAccount.annotations | object | `{}` | Additional ServiceAccount annotations |
 | serviceAccount.create | bool | `true` | Create service account |
 | serviceAccount.name | string | `""` | Service account name to use, when empty will be set to created account if |
 | serviceMonitor.enabled | bool | `false` | When set true then use a ServiceMonitor to configure scraping |
+| terminationGracePeriodSeconds | int | `300` | Specifies termination grace period, default: `300` |
 | tolerations | list | `[]` | Toleration labels for pod assignment |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/deploy/helm/pulumi-operator/README.md
+++ b/deploy/helm/pulumi-operator/README.md
@@ -82,6 +82,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | podSecurityContext.fsGroup | int | `1000` | pulumi-kubernetes-operator group is 1000 |
 | podSecurityContext.runAsUser | int | `1000` | pulumi-kubernetes-operator user is 1000 |
 | replicaCount | int | `1` | Specifies the replica count for the deployment |
+| terminationGracePeriodSeconds | int | `` | Specifies termination grace period |
 | resources | object | `{"limits":{"cpu":"500m","memory":"5123Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | CPU/Memory resource requests/limits |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"privileged":false,"runAsGroup":10003,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Security Context see [values.yaml](values.yaml) |
 | serviceAccount.annotations | object | `{}` | Additional ServiceAccount annotations |

--- a/deploy/helm/pulumi-operator/templates/deployment.yaml
+++ b/deploy/helm/pulumi-operator/templates/deployment.yaml
@@ -83,6 +83,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "pulumi-kubernetes-operator.serviceAccountName" . }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/deploy/helm/pulumi-operator/values.yaml
+++ b/deploy/helm/pulumi-operator/values.yaml
@@ -4,6 +4,9 @@ deploymentStrategy: ""
 # -- Specifies the replica count for the deployment
 replicaCount: 1
 
+# -- Specifies termination grace period
+terminationGracePeriodSeconds:
+
 image:
   # -- The image registry to pull from
   registry: docker.io

--- a/deploy/helm/pulumi-operator/values.yaml
+++ b/deploy/helm/pulumi-operator/values.yaml
@@ -4,8 +4,8 @@ deploymentStrategy: ""
 # -- Specifies the replica count for the deployment
 replicaCount: 1
 
-# -- Specifies termination grace period
-terminationGracePeriodSeconds:
+# -- Specifies termination grace period, default: `300`
+terminationGracePeriodSeconds: 300
 
 image:
   # -- The image registry to pull from


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

We would like to override value of terminationGracePeriodSeconds parameter. Unfortunately pulumi kubernetes operator helm chart is not setting this value.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

By default, the terminationGracePeriodSeconds parameter is not set, so the operator will take no action. If this parameter is set then the value will be overwritten.

impact/no-changelog-required
