### PR TITLE
Handle existing workspace directories better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG
 =========
 
 ## HEAD (unreleased)
+- Clean up stale workspace directories and don't treat them as a crude lock. [#552](https://github.com/pulumi/pulumi-kubernetes-operator/pull/552)
 
 ## 1.14.0 (2023-11-08)
 - Changed indentation in deploy/helm/pulumi-operator/templates/deployment.yaml for volumes and volumeMounts.

--- a/docs/create-stacks-using-kubectl.md
+++ b/docs/create-stacks-using-kubectl.md
@@ -250,7 +250,7 @@ kubectl delete secret pulumi-api-secret
 kubectl delete secret pulumi-aws-secrets
 ```
 
-Check out [`ext_s3_bucket_stack.yaml`](../stack-examples/yaml/ext_s3_bucket_stack.yaml) for an extended options exmaple.
+Check out [`ext_s3_bucket_stack.yaml`](../stack-examples/yaml/ext_s3_bucket_stack.yaml) for an extended options example.
 
 ## Troubleshooting
 

--- a/pkg/controller/stack/stack_controller.go
+++ b/pkg/controller/stack/stack_controller.go
@@ -477,7 +477,7 @@ func (r *ReconcileStack) Reconcile(ctx context.Context, request reconcile.Reques
 		return reconcile.Result{}, sess.finalize(ctx, instance)
 	}
 
-	// This makes sure the status reflects the outcome of reconcilation. Any non-error return means
+	// This makes sure the status reflects the outcome of reconciliation. Any non-error return means
 	// the object definition was observed, whether the object ended up in a ready state or not. An
 	// error return (now we have successfully fetched the object) means it is "in progress" and not
 	// ready.
@@ -1131,7 +1131,7 @@ func (sess *reconcileStackSession) resolveResourceRef(ctx context.Context, ref *
 			}
 			return string(secretVal), nil
 		}
-		return "", errors.New("Mising secret reference in ResourceRef")
+		return "", errors.New("Missing secret reference in ResourceRef")
 	default:
 		return "", fmt.Errorf("Unsupported selector type: %v", ref.SelectorType)
 	}


### PR DESCRIPTION
### Proposed changes

I've changed the stack reconciliation code to clean up existing workspace directories when it finds them instead of treating them as a lock and failing forever. We've seen numerous times where the operator leaves a workspace directory behind for some unknown reason and it causes the stack to fail to reconcile forever. The only way to resolve the issue is to remove the directory manually or restart the entire operator pod.

The operator shouldn't treat directories as locks in my opinion. Given that they're processed by 1 thread at a time and Pulumi has its own state lock files (for SaaS & self-hosted backends), an existing directory shouldn't block the reconciliation and cause a failure that never resolves itself.
 
Also, I fixed a few typos. Let me know if there's anything I've missed for this or if there's any concerns with this approach.
