### PR TITLE
fix: typo

### DIFF
--- a/deploy/helm/pulumi-operator/Chart.yaml
+++ b/deploy/helm/pulumi-operator/Chart.yaml
@@ -9,7 +9,7 @@ icon: https://www.pulumi.com/logos/brand/avatar-on-white.svg
 
 type: application
 
-version: 0.7.1
+version: 0.7.2
 appVersion: 1.14.0
 
 keywords:

--- a/deploy/helm/pulumi-operator/Chart.yaml
+++ b/deploy/helm/pulumi-operator/Chart.yaml
@@ -25,7 +25,7 @@ maintainers:
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - add cluster role and fluxcd crd rules to role
+    - Fix type in CRD
   artifacthub.io/images: |
     - name: pulumi-kubernetes-operator
       image: docker.io/pulumi-kubernetes-operator:v1.14.0

--- a/deploy/helm/pulumi-operator/README.md
+++ b/deploy/helm/pulumi-operator/README.md
@@ -1,6 +1,6 @@
 # node-red ⚙
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 1.14.0](https://img.shields.io/badge/AppVersion-1.14.0-informational?style=for-the-badge)
+![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 1.14.0](https://img.shields.io/badge/AppVersion-1.14.0-informational?style=for-the-badge)
 
 ## Description 📜
 
@@ -11,7 +11,7 @@ A Helm chart for the Pulumi Kubernetes Operator
 To install the chart using the OCI artifact, run:
 
 ```bash
-helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator --version 0.7.1
+helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator --version 0.7.2
 ```
 
 ## Usage
@@ -27,7 +27,7 @@ helm repo update
 To install the chart with the release name `pulumi-kubernetes-operator` run:
 
 ```bash
-helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --version 0.7.1
+helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --version 0.7.2
 ```
 
 After a few seconds, the `pulumi-kubernetes-operator` should be running.

--- a/deploy/helm/pulumi-operator/README.md
+++ b/deploy/helm/pulumi-operator/README.md
@@ -1,6 +1,6 @@
 # node-red ⚙
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 1.14.0](https://img.shields.io/badge/AppVersion-1.14.0-informational?style=for-the-badge)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 1.14.0](https://img.shields.io/badge/AppVersion-1.14.0-informational?style=for-the-badge)
 
 ## Description 📜
 
@@ -11,7 +11,7 @@ A Helm chart for the Pulumi Kubernetes Operator
 To install the chart using the OCI artifact, run:
 
 ```bash
-helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator --version 0.7.0
+helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator --version 0.7.1
 ```
 
 ## Usage
@@ -27,7 +27,7 @@ helm repo update
 To install the chart with the release name `pulumi-kubernetes-operator` run:
 
 ```bash
-helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --version 0.7.0
+helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --version 0.7.1
 ```
 
 After a few seconds, the `pulumi-kubernetes-operator` should be running.

--- a/deploy/helm/pulumi-operator/templates/role.yaml
+++ b/deploy/helm/pulumi-operator/templates/role.yaml
@@ -89,7 +89,7 @@ rules:
   - list
   - update
 - apiGroups:
-  - source.toolkit.fluxcd.io'
+  - source.toolkit.fluxcd.io
   resources:
   - '*'
   verbs:


### PR DESCRIPTION
This typo was leading to me scratching my head for a while on why the operator can't get the `ocirepositories` although the role needed is already there. cc: @dirien 