### PR TITLE
Update README.md to remove outdated helm instructions

### DIFF
--- a/.github/workflows/chart-lint-and-test.yml
+++ b/.github/workflows/chart-lint-and-test.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths:
       - deploy/helm/**
+      - "!deploy/helm/pulumi-operator/README.md"
+      - "!deploy/helm/pulumi-operator/README.md.gotmpl"
 
 permissions: read-all
 

--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -6,6 +6,9 @@ on:
       - master
     paths:
       - "deploy/helm/**"
+      - "!deploy/helm/pulumi-operator/README.md"
+      - "!deploy/helm/pulumi-operator/README.md.gotmpl"
+      
 env:
   HELM_DOCS_VERSION: "1.11.0"
 

--- a/deploy/helm/pulumi-operator/README.md
+++ b/deploy/helm/pulumi-operator/README.md
@@ -1,4 +1,4 @@
-# node-red ⚙
+# Pulumi Kubernetes Operator - Helm Chart
 
 ![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 1.14.0](https://img.shields.io/badge/AppVersion-1.14.0-informational?style=for-the-badge)
 

--- a/deploy/helm/pulumi-operator/README.md
+++ b/deploy/helm/pulumi-operator/README.md
@@ -14,29 +14,13 @@ To install the chart using the OCI artifact, run:
 helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator --version 0.7.2
 ```
 
-## Usage
-Adding `pulumi-kubernetes-operator` repository
-Before installing any chart provided by this repository, add the `pulumi-kubernetes-operator` Charts Repository:
-
-```bash
-helm repo add pulumi-kubernetes-operator https://pulumi.github.io/pulumi-kubernetes-operator/
-helm repo update
-```
-
-### Installing the Chart 📦
-To install the chart with the release name `pulumi-kubernetes-operator` run:
-
-```bash
-helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --version 0.7.2
-```
-
 After a few seconds, the `pulumi-kubernetes-operator` should be running.
 
 To install the chart in a specific namespace use following commands:
 
 ```bash
 kubectl create ns pulumi-kubernetes-operator
-helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --namespace pulumi-kubernetes-operator
+helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator --namespace pulumi-kubernetes-operator
 ```
 
 > **Tip**: List all releases using `helm list`, a release is a name used to track a specific deployment

--- a/deploy/helm/pulumi-operator/README.md.gotmpl
+++ b/deploy/helm/pulumi-operator/README.md.gotmpl
@@ -1,4 +1,4 @@
-# node-red ⚙
+# Pulumi Kubernetes Operator - Helm Chart
 
 {{ template "chart.badgesSection" . }}
 
@@ -14,29 +14,13 @@ To install the chart using the OCI artifact, run:
 helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator --version {{ .Version }}
 ```
 
-## Usage
-Adding `pulumi-kubernetes-operator` repository
-Before installing any chart provided by this repository, add the `pulumi-kubernetes-operator` Charts Repository:
-
-```bash
-helm repo add pulumi-kubernetes-operator https://pulumi.github.io/pulumi-kubernetes-operator/
-helm repo update
-```
-
-### Installing the Chart 📦
-To install the chart with the release name `pulumi-kubernetes-operator` run:
-
-```bash
-helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --version {{ .Version }}
-```
-
 After a few seconds, the `pulumi-kubernetes-operator` should be running.
 
 To install the chart in a specific namespace use following commands:
 
 ```bash
 kubectl create ns pulumi-kubernetes-operator
-helm install pulumi-kubernetes-operator pulumi-kubernetes-operator/pulumi-kubernetes-operator --namespace pulumi-kubernetes-operator
+helm install pulumi-kubernetes-operator oci://ghcr.io/pulumi/helm-charts/pulumi-kubernetes-operator --namespace pulumi-kubernetes-operator
 ```
 
 > **Tip**: List all releases using `helm list`, a release is a name used to track a specific deployment


### PR DESCRIPTION
We apparently only support installing via the oci artifact. (https://github.com/pulumi/pulumi-kubernetes-operator/issues/544#issuecomment-1980777127) 

Fixes https://github.com/pulumi/pulumi-kubernetes-operator/issues/544
