### PR TITLE
Use goreleaser v1

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: v1.26.2
           args: release --snapshot --skip-publish --rm-dist --skip-sign
   operator-int-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,6 +75,7 @@ jobs:
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
+          version: v1.26.2
           args: release --skip-sign
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-acceptance-tests.yaml
+++ b/.github/workflows/run-acceptance-tests.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: v1.26.2
           args: release --snapshot --skip-publish --rm-dist --skip-sign
   operator-int-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
v2 was released recently and [removed](https://goreleaser.com/blog/goreleaser-v2/#highlights) some CLI args. Continue to use the working v1 version for now.