### PR TITLE
[v2] Stable envRefs

### DIFF
--- a/.github/workflows/v2-run-acceptance-tests.yaml
+++ b/.github/workflows/v2-run-acceptance-tests.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -44,7 +44,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Install Pulumi
         uses: pulumi/actions@v5
       - name: Run Tests (Agent)
@@ -77,6 +77,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Run tests
         run: make -C operator test-e2e

--- a/.github/workflows/v2-run-acceptance-tests.yaml
+++ b/.github/workflows/v2-run-acceptance-tests.yaml
@@ -61,7 +61,6 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     name: E2E tests
-    if: false
     steps:
       # Building the rootless image currently eats up all of our free disk.
       - name: Free Disk Space (Ubuntu)

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the operator binary
-FROM --platform=${BUILDPLATFORM} golang:1.22 AS op-builder
+FROM --platform=${BUILDPLATFORM} golang:1.23 AS op-builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 images:
 - name: controller
   newName: pulumi/pulumi-kubernetes-operator-v2
-  newTag: latest
+  newTag: 8048c5700c1038f17cbcb255
 resources:
 - manager.yaml

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 images:
 - name: controller
   newName: pulumi/pulumi-kubernetes-operator-v2
-  newTag: 8048c5700c1038f17cbcb255
+  newTag: latest
 resources:
 - manager.yaml

--- a/operator/e2e/e2e_test.go
+++ b/operator/e2e/e2e_test.go
@@ -91,9 +91,6 @@ func TestE2E(t *testing.T) {
 
 				cmd := exec.Command("bash", "-c", "envsubst < e2e/testdata/git-auth-nonroot/* | kubectl apply -f -")
 				require.NoError(t, run(cmd))
-				t.Cleanup(func() {
-					_ = run(exec.Command("kubectl", "delete", "-f", "e2e/testdata/git-auth-nonroot"))
-				})
 
 				cmd = exec.Command("kubectl", "wait", "stacks/git-auth-nonroot",
 					"--for", "condition=Ready", "-n", "git-auth-nonroot", "--timeout", "300s")

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumi-kubernetes-operator/operator
 
-go 1.22.5
+go 1.23.1
 
 require (
 	github.com/fluxcd/source-controller/api v1.3.0

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path"
 	"slices"
@@ -34,7 +35,6 @@ import (
 	autov1alpha1 "github.com/pulumi/pulumi-kubernetes-operator/operator/api/auto/v1alpha1"
 	"github.com/pulumi/pulumi-kubernetes-operator/operator/api/pulumi/shared"
 	pulumiv1 "github.com/pulumi/pulumi-kubernetes-operator/operator/api/pulumi/v1"
-	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -886,8 +886,7 @@ func (sess *StackReconcilerSession) SetEnvRefsForWorkspace(ctx context.Context) 
 
 	// envRefs is an unordered map, but we need to constrct env vars
 	// deterministically to not thrash our underlying StatefulSet.
-	keys := maps.Keys(envRefs)
-	slices.Sort(keys)
+	keys := slices.Sorted(maps.Keys(envRefs))
 
 	for _, key := range keys {
 		ref := envRefs[key]


### PR DESCRIPTION
Stack CRDs that include `envRefs` will currently thrash the workspace's underlying StatefulSet because map order is undefined.

This sorts the envRef keys ahead of time to keep the StatefulSet stable. As a result we're also able to turn on the E2E test in CI since it should now succeed reliably.