### PR TITLE
[V2] Fix log spamming from cache misses when updating status repeatedly

### DIFF
--- a/operator/internal/controller/auto/update_controller.go
+++ b/operator/internal/controller/auto/update_controller.go
@@ -106,7 +106,7 @@ func (r *UpdateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		meta.SetStatusCondition(&obj.Status.Conditions, *rs.failed)
 		rs.complete.ObservedGeneration = obj.Generation
 		meta.SetStatusCondition(&obj.Status.Conditions, *rs.complete)
-		return r.Status().Update(ctx, obj)
+		return r.Status().Update(ctx, obj, client.FieldOwner(FieldManager))
 	}
 
 	if rs.complete.Status == metav1.ConditionTrue {

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -441,7 +441,7 @@ func (r *StackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 	}
 
 	saveStatus := func() error {
-		if err := r.Status().Update(ctx, instance); err != nil {
+		if err := r.Status().Update(ctx, instance, client.FieldOwner(FieldManager)); err != nil {
 			log.Error(err, "unable to save object status")
 			return err
 		}


### PR DESCRIPTION
### Proposed Changes

This PR addresses the issue of excessive log spam caused by reconcile loops being triggered in quick succession on the same Workspace object due to changes in its dependent resources (e.g., services, statefulsets). Previously, each reconcile loop attempted to update the Status subresource, but because the fetched object had an outdated `resourceVersion` (due to a stale cache), it would result in a conflict error. 

While `r.Update()` invalidates the cache, `r.Status().Update()` does not, leading to this conflict when only the status was updated in consecutive reconcile loops. The failed reconcile loop would eventually succeed once the cache was updated, but the log spam remained an issue.

This PR resolves the problem by patching the status subresource instead of performing an update, which avoids the need for the latest `resourceVersion` and prevents the conflict errors from occurring.

Refs #700

### Commits
1. Patch status subresource instead of using Update to prevent conflicts caused by cache miss.
2. Add a field manager to all Kubernetes API calls.