### PR TITLE
[v2] E2E test for --target

### DIFF
--- a/operator/e2e/e2e_test.go
+++ b/operator/e2e/e2e_test.go
@@ -104,6 +104,22 @@ func TestE2E(t *testing.T) {
 				assert.Equal(t, `"foo"`, string(stack.Status.Outputs["simpleOutput"].Raw))
 			},
 		},
+		{
+			name: "targets",
+			f: func(t *testing.T) {
+				t.Parallel()
+
+				cmd := exec.Command("kubectl", "apply", "-f", "e2e/testdata/targets")
+				require.NoError(t, run(cmd))
+				dumpLogs(t, "targets", "pod/targets-workspace-0")
+
+				stack, err := waitFor[pulumiv1.Stack]("stacks/targets", "targets", "condition=Ready", 5*time.Minute)
+				assert.NoError(t, err)
+
+				assert.Contains(t, stack.Status.Outputs, "targeted")
+				assert.NotContains(t, stack.Status.Outputs, "notTargeted")
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/operator/e2e/testdata/git-auth-nonroot/manifests.yaml
+++ b/operator/e2e/testdata/git-auth-nonroot/manifests.yaml
@@ -54,7 +54,6 @@ spec:
         value: "test"
   workspaceTemplate:
     spec:
-      image: pulumi/pulumi:3.134.1-nonroot
       podTemplate:
         spec:
           containers:

--- a/operator/e2e/testdata/targets/manifests.yaml
+++ b/operator/e2e/testdata/targets/manifests.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: targets
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: state
+  namespace: targets
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: pulumi.com/v1
+kind: Program
+metadata:
+  name: targets
+  namespace: targets
+program:
+  resources:
+    notTargeted:
+      type: random:RandomInteger
+      properties:
+        min: 1
+        max: 100
+    targeted:
+      type: random:RandomInteger
+      properties:
+        min: 1
+        max: 100
+  outputs:
+    targeted: ${targeted.result}
+    notTargeted: ${notTargeted.result} # Should be absent
+---
+apiVersion: pulumi.com/v1
+kind: Stack
+metadata:
+  name: targets
+  namespace: targets
+spec:
+  stack: dev
+  programRef:
+    name: targets
+  targets:
+    - urn:pulumi:dev::targets::random:index/randomInteger:RandomInteger::targeted
+
+  # Enable file state for testing.
+  envRefs:
+    PULUMI_BACKEND_URL:
+      type: Literal
+      literal:
+        value: "file:///state/"
+    PULUMI_CONFIG_PASSPHRASE:
+      type: Literal
+      literal:
+        value: "test"
+  workspaceTemplate:
+    spec:
+      image: pulumi/pulumi:3.130.0-nonroot
+      podTemplate:
+        spec:
+          containers:
+            - name: pulumi
+              volumeMounts:
+                - name: state
+                  mountPath: /state
+          volumes:
+            - name: state
+              persistentVolumeClaim:
+                claimName: state

--- a/operator/e2e/testdata/targets/manifests.yaml
+++ b/operator/e2e/testdata/targets/manifests.yaml
@@ -61,7 +61,6 @@ spec:
         value: "test"
   workspaceTemplate:
     spec:
-      image: pulumi/pulumi:3.130.0-nonroot
       podTemplate:
         spec:
           containers:


### PR DESCRIPTION
Turns out we already plumb target from Stack → Update → Agent → Auto API:

https://github.com/pulumi/pulumi-kubernetes-operator/blob/2a67d4c436a95073de99b0bebcf77ea5f146e5f6/operator/internal/controller/pulumi/stack_controller.go#L1260-L1261

https://github.com/pulumi/pulumi-kubernetes-operator/blob/2a67d4c436a95073de99b0bebcf77ea5f146e5f6/operator/internal/controller/auto/update_controller.go#L214-L215

https://github.com/pulumi/pulumi-kubernetes-operator/blob/2a67d4c436a95073de99b0bebcf77ea5f146e5f6/agent/pkg/server/server.go#L486-L490

This adds a small E2E test around the behavior.