### PR TITLE
Use sequential numbering for naming the Update object

### DIFF
--- a/deploy/crds/auto.pulumi.com_updates.yaml
+++ b/deploy/crds/auto.pulumi.com_updates.yaml
@@ -18,6 +18,10 @@ spec:
     - jsonPath: .spec.workspaceName
       name: Workspace
       type: string
+    - jsonPath: .spec.type
+      name: Type
+      priority: 10
+      type: string
     - jsonPath: .status.startTime
       name: Start Time
       priority: 10

--- a/deploy/helm/pulumi-operator/crds/auto.pulumi.com_updates.yaml
+++ b/deploy/helm/pulumi-operator/crds/auto.pulumi.com_updates.yaml
@@ -18,6 +18,10 @@ spec:
     - jsonPath: .spec.workspaceName
       name: Workspace
       type: string
+    - jsonPath: .spec.type
+      name: Type
+      priority: 10
+      type: string
     - jsonPath: .status.startTime
       name: Start Time
       priority: 10

--- a/operator/api/auto/v1alpha1/update_types.go
+++ b/operator/api/auto/v1alpha1/update_types.go
@@ -113,6 +113,7 @@ type UpdateStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Workspace",type=string,JSONPath=`.spec.workspaceName`
+//+kubebuilder:printcolumn:name="Type",type=string,priority=10,JSONPath=`.spec.type`
 //+kubebuilder:printcolumn:name="Start Time",type=date,priority=10,JSONPath=`.status.startTime`
 //+kubebuilder:printcolumn:name="End Time",type=date,priority=10,JSONPath=`.status.endTime`
 //+kubebuilder:printcolumn:name="Progressing",type=string,JSONPath=`.status.conditions[?(@.type=="Progressing")].status`

--- a/operator/config/crd/bases/auto.pulumi.com_updates.yaml
+++ b/operator/config/crd/bases/auto.pulumi.com_updates.yaml
@@ -18,6 +18,10 @@ spec:
     - jsonPath: .spec.workspaceName
       name: Workspace
       type: string
+    - jsonPath: .spec.type
+      name: Type
+      priority: 10
+      type: string
     - jsonPath: .status.startTime
       name: Start Time
       priority: 10

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -46,7 +46,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -1419,7 +1418,7 @@ func (sess *stackReconcilerSession) newDestroy(ctx context.Context, o *pulumiv1.
 }
 
 func makeUpdateName(o *pulumiv1.Stack) string {
-	return fmt.Sprintf("%s-%s", o.Name, utilrand.String(8))
+	return fmt.Sprintf("%s-%x", o.Name, time.Now().UnixMilli())
 }
 
 func (sess *stackReconcilerSession) readCurrentUpdate(ctx context.Context, name types.NamespacedName) error {


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Use a sequential numbering strategy for the stack update objects.

Before:
```
NAME                   WORKSPACE     PROGRESSING   FAILED   COMPLETE   URL
random-yaml-tf9hxngl   random-yaml                                     
random-yaml-tf9hxngl   random-yaml   True          False    False      
random-yaml-tf9hxngl   random-yaml   False         False    True       https://app.pulumi.com/eron-pulumi-corp/random/dev/updates/4814
random-yaml-vqzmzxtr   random-yaml                                     
random-yaml-vqzmzxtr   random-yaml   True          False    False      
random-yaml-vqzmzxtr   random-yaml   False         False    True       https://app.pulumi.com/eron-pulumi-corp/random/dev/updates/4815
random-yaml-m4wm7dzt   random-yaml                                     
random-yaml-m4wm7dzt   random-yaml   True          False    False      
random-yaml-m4wm7dzt   random-yaml   False         False    True       https://app.pulumi.com/eron-pulumi-corp/random/dev/updates/4816
```

After:
```
NAME                      WORKSPACE     PROGRESSING   FAILED   COMPLETE   URL
random-yaml-1929cadf4a8   random-yaml                                     
random-yaml-1929cadf4a8   random-yaml   True          False    False      
random-yaml-1929cadf4a8   random-yaml   False         False    True       https://app.pulumi.com/eron-pulumi-corp/random/dev/updates/4828
random-yaml-1929caf016f   random-yaml                                     
random-yaml-1929caf016f   random-yaml   True          False    False      
random-yaml-1929caf016f   random-yaml   False         False    True       https://app.pulumi.com/eron-pulumi-corp/random/dev/updates/4829
random-yaml-1929cb00a8f   random-yaml                                     
random-yaml-1929cb00a8f   random-yaml   True          False    False      
random-yaml-1929cb00a8f   random-yaml   False         False    True       https://app.pulumi.com/eron-pulumi-corp/random/dev/updates/4830

```

When you list the completed updates, they're now in order:
```
❯ kubectl get update
NAME                      WORKSPACE     PROGRESSING   FAILED   COMPLETE   URL
random-yaml-1929cadf4a8   random-yaml   False         False    True       https://app.pulumi.com/eron-pulumi-corp/random/dev/updates/4828
random-yaml-1929caf016f   random-yaml   False         False    True       https://app.pulumi.com/eron-pulumi-corp/random/dev/updates/4829
random-yaml-1929cb00a8f   random-yaml   False         False    True       https://app.pulumi.com/eron-pulumi-corp/random/dev/updates/4830
random-yaml-1929cb11670   random-yaml   False         False    True       https://app.pulumi.com/eron-pulumi-corp/random/dev/updates/4831
random-yaml-1929cb22165   random-yaml   False         False    True       https://app.pulumi.com/eron-pulumi-corp/random/dev/updates/4832
random-yaml-1929cb32d64   random-yaml   False         False    True       https://app.pulumi.com/eron-pulumi-corp/random/dev/updates/4833
random-yaml-1929cb43738   random-yaml   False         False    True       https://app.pulumi.com/eron-pulumi-corp/random/dev/updates/4834
random-yaml-1929cb540cb   random-yaml   False         False    True       https://app.pulumi.com/eron-pulumi-corp/random/dev/updates/4835

```
### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #710 