### PR TITLE
improved status logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## Unreleased
 
 - Improved support for using custom program sources. [#741](https://github.com/pulumi/pulumi-kubernetes-operator/pull/741) 
+- Improved Status logging. [#742](https://github.com/pulumi/pulumi-kubernetes-operator/pull/742)
 
 ## 2.0.0-beta.1 (2024-10-18)
 

--- a/operator/internal/controller/auto/workspace_controller.go
+++ b/operator/internal/controller/auto/workspace_controller.go
@@ -104,6 +104,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 	updateStatus := func() error {
+		oldRevision := w.ResourceVersion
 		w.Status.ObservedGeneration = w.Generation
 		ready.ObservedGeneration = w.Generation
 		meta.SetStatusCondition(&w.Status.Conditions, *ready)
@@ -111,8 +112,13 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err != nil {
 			l.Error(err, "updating status")
 		} else {
-			l = log.FromContext(ctx).WithValues("revision", w.ResourceVersion)
-			l.V(1).Info("Status updated")
+			if w.ResourceVersion != oldRevision {
+				l = log.FromContext(ctx).WithValues("revision", w.ResourceVersion)
+				l.Info("Status updated",
+					"observedGeneration", w.Status.ObservedGeneration,
+					"address", w.Status.Address,
+					"conditions", w.Status.Conditions)
+			}
 		}
 
 		return err

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -494,12 +494,20 @@ func (r *StackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 	}
 
 	saveStatus := func() error {
+		oldRevision := instance.ResourceVersion
 		if err := r.Status().Update(ctx, instance); err != nil {
 			log.Error(err, "unable to save object status")
 			return err
 		}
-		log = ctrllog.FromContext(ctx).WithValues("revision", instance.ResourceVersion)
-		log.V(1).Info("Status updated")
+		if instance.ResourceVersion != oldRevision {
+			log = ctrllog.FromContext(ctx).WithValues("revision", instance.ResourceVersion)
+			log.Info("Status updated",
+				"observedGeneration", instance.Status.ObservedGeneration,
+				"observedReconcileRequest", instance.Status.ObservedReconcileRequest,
+				"lastUpdate", instance.Status.LastUpdate,
+				"currentUpdate", instance.Status.CurrentUpdate,
+				"conditions", instance.Status.Conditions)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Ensures that an info-level log line is emitted whenever the status is substantially changed on a given object.  The resultant log is more useful for troubleshooting when we don't have access to the cluster or the status information within the `Stack` object.

For example, here's the series of status updates that occurs when a new stack is deployed.

```log
2024-11-06T13:30:50-08:00	INFO	Status updated	{"controller": "stack-controller", "namespace": "default", "name": "random-yaml", "reconcileID": "47deadf8-cc74-4f30-92cf-a2781babd58b", "revision": "2119184", "observedGeneration": 0, "observedReconcileRequest": "", "lastUpdate": null, "currentUpdate": null, "conditions": [{"type":"Ready","status":"False","lastTransitionTime":"2024-11-06T21:30:50Z","reason":"NotReadyInProgress","message":"reconciliation is in progress"},{"type":"Reconciling","status":"True","lastTransitionTime":"2024-11-06T21:30:50Z","reason":"StackProcessing","message":"waiting for workspace readiness"}]}
2024-11-06T13:30:50-08:00	INFO	Status updated	{"controller": "workspace-controller", "controllerGroup": "auto.pulumi.com", "controllerKind": "Workspace", "Workspace": {"name":"random-yaml","namespace":"default"}, "namespace": "default", "name": "random-yaml", "reconcileID": "ffe76e47-b703-4d07-bfb0-a50645113862", "revision": "2119189", "observedGeneration": 1, "address": "", "conditions": [{"type":"Ready","status":"False","observedGeneration":1,"lastTransitionTime":"2024-11-06T21:30:50Z","reason":"RollingUpdate","message":"Waiting for the statefulset to be updated"}]}
2024-11-06T13:30:50-08:00	INFO	Status updated	{"controller": "stack-controller", "namespace": "default", "name": "random-yaml", "reconcileID": "99af995b-303f-41a2-908d-d4427e8e0648", "revision": "2119198", "observedGeneration": 2, "observedReconcileRequest": "", "lastUpdate": null, "currentUpdate": null, "conditions": [{"type":"Ready","status":"False","lastTransitionTime":"2024-11-06T21:30:50Z","reason":"NotReadyInProgress","message":"reconciliation is in progress"},{"type":"Reconciling","status":"True","lastTransitionTime":"2024-11-06T21:30:50Z","reason":"StackProcessing","message":"waiting for workspace readiness"}]}
2024-11-06T13:30:54-08:00	INFO	Status updated	{"controller": "workspace-controller", "controllerGroup": "auto.pulumi.com", "controllerKind": "Workspace", "Workspace": {"name":"random-yaml","namespace":"default"}, "namespace": "default", "name": "random-yaml", "reconcileID": "7dab6d15-1c5c-42fc-9bc7-d96dfbcffaf8", "revision": "2119226", "observedGeneration": 1, "address": "", "conditions": [{"type":"Ready","status":"False","observedGeneration":1,"lastTransitionTime":"2024-11-06T21:30:50Z","reason":"ConnectionFailed","message":"unable to connect to workspace: TRANSIENT_FAILURE"}]}
2024-11-06T13:30:59-08:00	INFO	Status updated	{"controller": "workspace-controller", "controllerGroup": "auto.pulumi.com", "controllerKind": "Workspace", "Workspace": {"name":"random-yaml","namespace":"default"}, "namespace": "default", "name": "random-yaml", "reconcileID": "c12c6630-089f-4783-ab1f-856796961888", "revision": "2119239", "observedGeneration": 1, "address": "random-yaml-workspace.default.svc.cluster.local:50051", "conditions": [{"type":"Ready","status":"False","observedGeneration":1,"lastTransitionTime":"2024-11-06T21:30:50Z","reason":"Installing","message":"Installing packages and plugins required by the program"}]}
2024-11-06T13:31:01-08:00	INFO	Status updated	{"controller": "workspace-controller", "controllerGroup": "auto.pulumi.com", "controllerKind": "Workspace", "Workspace": {"name":"random-yaml","namespace":"default"}, "namespace": "default", "name": "random-yaml", "reconcileID": "c12c6630-089f-4783-ab1f-856796961888", "revision": "2119244", "observedGeneration": 1, "address": "random-yaml-workspace.default.svc.cluster.local:50051", "conditions": [{"type":"Ready","status":"False","observedGeneration":1,"lastTransitionTime":"2024-11-06T21:30:50Z","reason":"Initializing","message":"Initializing and selecting a Pulumi stack"}]}
2024-11-06T13:31:04-08:00	INFO	Status updated	{"controller": "workspace-controller", "controllerGroup": "auto.pulumi.com", "controllerKind": "Workspace", "Workspace": {"name":"random-yaml","namespace":"default"}, "namespace": "default", "name": "random-yaml", "reconcileID": "c12c6630-089f-4783-ab1f-856796961888", "revision": "2119253", "observedGeneration": 1, "address": "random-yaml-workspace.default.svc.cluster.local:50051", "conditions": [{"type":"Ready","status":"True","observedGeneration":1,"lastTransitionTime":"2024-11-06T21:30:50Z","reason":"Succeeded","message":""}]}
2024-11-06T13:31:04-08:00	INFO	Status updated	{"controller": "stack-controller", "namespace": "default", "name": "random-yaml", "reconcileID": "da8dcf8a-09cd-4705-a8a4-0f61c5fba359", "revision": "2119255", "observedGeneration": 2, "observedReconcileRequest": "", "lastUpdate": null, "currentUpdate": {"generation":2,"name":"random-yaml-193036360e1","commit":"sha256:3227b4cdbdb3492b7bdff13f9acbfe6e679eee55753b48f0467e2ab7e9342350"}, "conditions": [{"type":"Ready","status":"False","lastTransitionTime":"2024-11-06T21:30:50Z","reason":"NotReadyInProgress","message":"reconciliation is in progress"},{"type":"Reconciling","status":"True","lastTransitionTime":"2024-11-06T21:30:50Z","reason":"StackProcessing","message":"stack is being processed"}]}
2024-11-06T13:31:04-08:00	INFO	Status updated	{"controller": "update-controller", "controllerGroup": "auto.pulumi.com", "controllerKind": "Update", "Update": {"name":"random-yaml-193036360e1","namespace":"default"}, "namespace": "default", "name": "random-yaml-193036360e1", "reconcileID": "e1fe3034-b49a-4937-ab79-181d5b2c798a", "revision": "2119256", "revision": "2119257", "observedGeneration": 1, "message": "", "conditions": [{"type":"Progressing","status":"True","observedGeneration":1,"lastTransitionTime":"2024-11-06T21:31:04Z","reason":"Progressing","message":""},{"type":"Failed","status":"False","observedGeneration":1,"lastTransitionTime":"2024-11-06T21:31:04Z","reason":"Progressing","message":""},{"type":"Complete","status":"False","observedGeneration":1,"lastTransitionTime":"2024-11-06T21:31:04Z","reason":"Progressing","message":""}]}
2024-11-06T13:31:12-08:00	INFO	Status updated	{"controller": "update-controller", "controllerGroup": "auto.pulumi.com", "controllerKind": "Update", "Update": {"name":"random-yaml-193036360e1","namespace":"default"}, "namespace": "default", "name": "random-yaml-193036360e1", "reconcileID": "e1fe3034-b49a-4937-ab79-181d5b2c798a", "revision": "2119256", "revision": "2119275", "observedGeneration": 1, "message": "\"Stack Update (up)\"", "conditions": [{"type":"Progressing","status":"False","observedGeneration":1,"lastTransitionTime":"2024-11-06T21:31:12Z","reason":"Complete","message":""},{"type":"Failed","status":"False","observedGeneration":1,"lastTransitionTime":"2024-11-06T21:31:04Z","reason":"succeeded","message":"\"Stack Update (up)\""},{"type":"Complete","status":"True","observedGeneration":1,"lastTransitionTime":"2024-11-06T21:31:12Z","reason":"Updated","message":""}]}
2024-11-06T13:31:13-08:00	INFO	Status updated	{"controller": "stack-controller", "namespace": "default", "name": "random-yaml", "reconcileID": "225be101-a526-48b2-be77-01748cb31c4d", "revision": "2119277", "observedGeneration": 2, "observedReconcileRequest": "", "lastUpdate": {"generation":2,"name":"random-yaml-193036360e1","type":"up","state":"succeeded","lastAttemptedCommit":"sha256:3227b4cdbdb3492b7bdff13f9acbfe6e679eee55753b48f0467e2ab7e9342350","lastSuccessfulCommit":"sha256:3227b4cdbdb3492b7bdff13f9acbfe6e679eee55753b48f0467e2ab7e9342350","permalink":"https://app.pulumi.com/eron-pulumi-corp/random/dev/updates/4900","lastResyncTime":"2024-11-06T21:31:12Z","failures":0}, "currentUpdate": null, "conditions": [{"type":"Ready","status":"True","lastTransitionTime":"2024-11-06T21:31:12Z","reason":"ProcessingCompleted","message":"the stack has been processed and is up to date"}]}

```

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #732 
Closes #354 