### PR TITLE
support for ReconcileRequest annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 
 - Improved support for using custom program sources. [#741](https://github.com/pulumi/pulumi-kubernetes-operator/pull/741) 
 - Improved Status logging. [#742](https://github.com/pulumi/pulumi-kubernetes-operator/pull/742)
+- Support for ReconcileRequest annotation. [#745](https://github.com/pulumi/pulumi-kubernetes-operator/pull/745)
 
 ## 2.0.0-beta.1 (2024-10-18)
 

--- a/deploy/crds/pulumi.com_stacks.yaml
+++ b/deploy/crds/pulumi.com_stacks.yaml
@@ -9518,6 +9518,10 @@ spec:
                   name:
                     description: Name is the name of the update object.
                     type: string
+                  reconcileRequest:
+                    description: ReconcileRequest is the stack reconcile request associated
+                      with the update.
+                    type: string
                 type: object
               lastUpdate:
                 description: LastUpdate contains details of the status of the last
@@ -9553,6 +9557,10 @@ spec:
                     description: Permalink is the Pulumi Console URL of the stack
                       operation.
                     type: string
+                  reconcileRequest:
+                    description: ReconcileRequest is the stack reconcile request associated
+                      with the update.
+                    type: string
                   state:
                     description: State is the state of the stack update - one of `succeeded`
                       or `failed`
@@ -9560,8 +9568,6 @@ spec:
                   type:
                     description: Type is the type of update.
                     type: string
-                required:
-                - failures
                 type: object
               observedGeneration:
                 description: ObservedGeneration records the value of .meta.generation
@@ -19035,6 +19041,10 @@ spec:
                     description: Permalink is the Pulumi Console URL of the stack
                       operation.
                     type: string
+                  reconcileRequest:
+                    description: ReconcileRequest is the stack reconcile request associated
+                      with the update.
+                    type: string
                   state:
                     description: State is the state of the stack update - one of `succeeded`
                       or `failed`
@@ -19042,8 +19052,6 @@ spec:
                   type:
                     description: Type is the type of update.
                     type: string
-                required:
-                - failures
                 type: object
               outputs:
                 additionalProperties:

--- a/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
+++ b/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
@@ -9518,6 +9518,10 @@ spec:
                   name:
                     description: Name is the name of the update object.
                     type: string
+                  reconcileRequest:
+                    description: ReconcileRequest is the stack reconcile request associated
+                      with the update.
+                    type: string
                 type: object
               lastUpdate:
                 description: LastUpdate contains details of the status of the last
@@ -9553,6 +9557,10 @@ spec:
                     description: Permalink is the Pulumi Console URL of the stack
                       operation.
                     type: string
+                  reconcileRequest:
+                    description: ReconcileRequest is the stack reconcile request associated
+                      with the update.
+                    type: string
                   state:
                     description: State is the state of the stack update - one of `succeeded`
                       or `failed`
@@ -9560,8 +9568,6 @@ spec:
                   type:
                     description: Type is the type of update.
                     type: string
-                required:
-                - failures
                 type: object
               observedGeneration:
                 description: ObservedGeneration records the value of .meta.generation
@@ -19035,6 +19041,10 @@ spec:
                     description: Permalink is the Pulumi Console URL of the stack
                       operation.
                     type: string
+                  reconcileRequest:
+                    description: ReconcileRequest is the stack reconcile request associated
+                      with the update.
+                    type: string
                   state:
                     description: State is the state of the stack update - one of `succeeded`
                       or `failed`
@@ -19042,8 +19052,6 @@ spec:
                   type:
                     description: Type is the type of update.
                     type: string
-                required:
-                - failures
                 type: object
               outputs:
                 additionalProperties:

--- a/deploy/yaml/install.yaml
+++ b/deploy/yaml/install.yaml
@@ -9753,6 +9753,10 @@ spec:
                   name:
                     description: Name is the name of the update object.
                     type: string
+                  reconcileRequest:
+                    description: ReconcileRequest is the stack reconcile request associated
+                      with the update.
+                    type: string
                 type: object
               lastUpdate:
                 description: LastUpdate contains details of the status of the last
@@ -9788,6 +9792,10 @@ spec:
                     description: Permalink is the Pulumi Console URL of the stack
                       operation.
                     type: string
+                  reconcileRequest:
+                    description: ReconcileRequest is the stack reconcile request associated
+                      with the update.
+                    type: string
                   state:
                     description: State is the state of the stack update - one of `succeeded`
                       or `failed`
@@ -9795,8 +9803,6 @@ spec:
                   type:
                     description: Type is the type of update.
                     type: string
-                required:
-                - failures
                 type: object
               observedGeneration:
                 description: ObservedGeneration records the value of .meta.generation
@@ -19270,6 +19276,10 @@ spec:
                     description: Permalink is the Pulumi Console URL of the stack
                       operation.
                     type: string
+                  reconcileRequest:
+                    description: ReconcileRequest is the stack reconcile request associated
+                      with the update.
+                    type: string
                   state:
                     description: State is the state of the stack update - one of `succeeded`
                       or `failed`
@@ -19277,8 +19287,6 @@ spec:
                   type:
                     description: Type is the type of update.
                     type: string
-                required:
-                - failures
                 type: object
               outputs:
                 additionalProperties:

--- a/operator/api/pulumi/shared/stack_types.go
+++ b/operator/api/pulumi/shared/stack_types.go
@@ -381,6 +381,8 @@ type StackOutputs map[string]apiextensionsv1.JSON
 type StackUpdateState struct {
 	// Generation is the stack generation associated with the update.
 	Generation int64 `json:"generation,omitempty"`
+	// ReconcileRequest is the stack reconcile request associated with the update.
+	ReconcileRequest string `json:"reconcileRequest,omitempty"`
 	// Name is the name of the update object.
 	Name string `json:"name,omitempty"`
 	// Type is the type of update.
@@ -398,7 +400,7 @@ type StackUpdateState struct {
 	// Failures records how many times the update has been attempted and
 	// failed. Failed updates are periodically retried with exponential backoff
 	// in case the failure was due to transient conditions.
-	Failures int64 `json:"failures"`
+	Failures int64 `json:"failures,omitempty"`
 }
 
 // StackUpdateStatus is the status code for the result of a Stack Update run.
@@ -435,6 +437,8 @@ type Permalink string
 type CurrentStackUpdate struct {
 	// Generation is the stack generation associated with the update.
 	Generation int64 `json:"generation,omitempty"`
+	// ReconcileRequest is the stack reconcile request associated with the update.
+	ReconcileRequest string `json:"reconcileRequest,omitempty"`
 	// Name is the name of the update object.
 	Name string `json:"name,omitempty"`
 	// Commit is the commit SHA of the planned update.

--- a/operator/config/crd/bases/pulumi.com_stacks.yaml
+++ b/operator/config/crd/bases/pulumi.com_stacks.yaml
@@ -9518,6 +9518,10 @@ spec:
                   name:
                     description: Name is the name of the update object.
                     type: string
+                  reconcileRequest:
+                    description: ReconcileRequest is the stack reconcile request associated
+                      with the update.
+                    type: string
                 type: object
               lastUpdate:
                 description: LastUpdate contains details of the status of the last
@@ -9553,6 +9557,10 @@ spec:
                     description: Permalink is the Pulumi Console URL of the stack
                       operation.
                     type: string
+                  reconcileRequest:
+                    description: ReconcileRequest is the stack reconcile request associated
+                      with the update.
+                    type: string
                   state:
                     description: State is the state of the stack update - one of `succeeded`
                       or `failed`
@@ -9560,8 +9568,6 @@ spec:
                   type:
                     description: Type is the type of update.
                     type: string
-                required:
-                - failures
                 type: object
               observedGeneration:
                 description: ObservedGeneration records the value of .meta.generation
@@ -19035,6 +19041,10 @@ spec:
                     description: Permalink is the Pulumi Console URL of the stack
                       operation.
                     type: string
+                  reconcileRequest:
+                    description: ReconcileRequest is the stack reconcile request associated
+                      with the update.
+                    type: string
                   state:
                     description: State is the state of the stack update - one of `succeeded`
                       or `failed`
@@ -19042,8 +19052,6 @@ spec:
                   type:
                     description: Type is the type of update.
                     type: string
-                required:
-                - failures
                 type: object
               outputs:
                 additionalProperties:

--- a/operator/internal/controller/pulumi/stack_controller_test.go
+++ b/operator/internal/controller/pulumi/stack_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	fluxsourcev1 "github.com/fluxcd/source-controller/api/v1"
+	"github.com/go-logr/logr/testr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -1069,7 +1070,7 @@ var _ = Describe("Stack Controller", func() {
 						LastSuccessfulCommit: "abcdef",
 					}
 				})
-				beNotSatisfied(ContainSubstring(errRequirementOutOfDate.Error()))
+				beNotSatisfied(ContainSubstring("prerequisite succeeded but not since"))
 			})
 
 			When("the prerequisite was synced recently", func() {
@@ -1467,7 +1468,8 @@ func TestIsSynced(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isSynced(&tt.stack, tt.currentCommit))
+			log := testr.New(t)
+			assert.Equal(t, tt.want, isSynced(log, &tt.stack, tt.currentCommit))
 		})
 	}
 }


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Implements support for requesting a re-sync of the stack (i.e. `pulumi up`) using the
`pulumi.com/reconciliation-request` annotation.

The logic of checking the prerequisites was moved to be after the check for "is synced", since the prereq check has the side-effect of touching the parent stack, and that shouldn't happen unless the child is needing a sync.  

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #672 
Closes #398
