### PR TITLE
Some stack outputs cannot be saved to Secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 - Improved Status logging. [#742](https://github.com/pulumi/pulumi-kubernetes-operator/pull/742)
 - Support for ReconcileRequest annotation. [#745](https://github.com/pulumi/pulumi-kubernetes-operator/pull/745)
 - Show stack processing state in printer columns. [#747](https://github.com/pulumi/pulumi-kubernetes-operator/pull/747)
+- Some stack outputs cannot be saved to Secret. [#746](https://github.com/pulumi/pulumi-kubernetes-operator/pull/746)
 
 ## 2.0.0-beta.1 (2024-10-18)
 

--- a/operator/internal/controller/auto/update_controller.go
+++ b/operator/internal/controller/auto/update_controller.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -485,8 +486,13 @@ func outputsToSecret(owner *autov1alpha1.Update, outputs map[string]*agentpb.Out
 	}})
 
 	secrets := []string{}
-	for k, v := range outputs {
-		// v.Value is already JSON-encoded bytes,
+	for outputName, v := range outputs {
+		// note: v.Value is already JSON-encoded bytes
+		k := outputName
+		if strings.Contains(k, " ") {
+			// sanitize the outputName to be a valid secret key
+			k = strings.ReplaceAll(k, " ", "_")
+		}
 		s.Data[k] = v.Value
 		if v.Secret {
 			secrets = append(secrets, k)

--- a/operator/internal/controller/auto/update_controller_test.go
+++ b/operator/internal/controller/auto/update_controller_test.go
@@ -119,8 +119,9 @@ func TestUpdate(t *testing.T) {
 				result := &agentpb.UpStream_Result{Result: &agentpb.UpResult{
 					Summary: &agentpb.UpdateSummary{Result: "succeeded"},
 					Outputs: map[string]*agentpb.OutputValue{
-						"username": {Value: []byte("username")},
-						"password": {Value: []byte("hunter2"), Secret: true},
+						"username":        {Value: []byte("username")},
+						"password":        {Value: []byte("hunter2"), Secret: true},
+						"with whitespace": {Value: []byte("with whitespace"), Secret: true},
 					},
 				}}
 
@@ -141,13 +142,14 @@ func TestUpdate(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "foo-stack-outputs",
 						Annotations: map[string]string{
-							"pulumi.com/secrets": `["password"]`,
+							"pulumi.com/secrets": `["password","with_whitespace"]`,
 						},
 						OwnerReferences: []metav1.OwnerReference{{UID: "uid", Name: "foo"}},
 					},
 					Data: map[string][]byte{
-						"username": []byte("username"),
-						"password": []byte("hunter2"),
+						"username":        []byte("username"),
+						"password":        []byte("hunter2"),
+						"with_whitespace": []byte("with whitespace"),
 					},
 					Immutable: ptr.To(true),
 				}


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

This PR sanitizes the output names from a given `Update` when the outputs are stored into a `Secret`.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #743