### PR TITLE
stack controller: watch for delete events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## Unreleased
+
+- Stack Controller: watch for delete events. [#756](https://github.com/pulumi/pulumi-kubernetes-operator/pull/756)
+
 ## 2.0.0-beta.2 (2024-11-11)
 
 - Improved support for using custom program sources. [#741](https://github.com/pulumi/pulumi-kubernetes-operator/pull/741) 

--- a/operator/internal/controller/auto/update_controller.go
+++ b/operator/internal/controller/auto/update_controller.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"sort"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -497,6 +498,7 @@ func outputsToSecret(owner *autov1alpha1.Update, outputs map[string]*agentpb.Out
 			secrets = append(secrets, k)
 		}
 	}
+	sort.Strings(secrets)
 
 	annotation, err := json.Marshal(secrets)
 	if err != nil {

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -378,7 +378,7 @@ func (stackReadyPredicate) Create(e event.CreateEvent) bool {
 }
 
 func (stackReadyPredicate) Delete(_ event.DeleteEvent) bool {
-	return false
+	return true
 }
 
 func (stackReadyPredicate) Update(e event.UpdateEvent) bool {
@@ -408,7 +408,7 @@ func (workspaceReadyPredicate) Create(e event.CreateEvent) bool {
 }
 
 func (workspaceReadyPredicate) Delete(_ event.DeleteEvent) bool {
-	return false
+	return true
 }
 
 func (workspaceReadyPredicate) Update(e event.UpdateEvent) bool {
@@ -438,7 +438,7 @@ func (updateCompletePredicate) Create(e event.CreateEvent) bool {
 }
 
 func (updateCompletePredicate) Delete(e event.DeleteEvent) bool {
-	return false
+	return true
 }
 
 func (updateCompletePredicate) Update(e event.UpdateEvent) bool {

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -393,7 +393,7 @@ func (stackReadyPredicate) Generic(_ event.GenericEvent) bool {
 }
 
 func isWorkspaceReady(ws *autov1alpha1.Workspace) bool {
-	if ws == nil || ws.Generation != ws.Status.ObservedGeneration {
+	if ws == nil || !ws.DeletionTimestamp.IsZero() || ws.Generation != ws.Status.ObservedGeneration {
 		return false
 	}
 	return meta.IsStatusConditionTrue(ws.Status.Conditions, autov1alpha1.WorkspaceReady)


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Ensures that progress is made if the Workspace object is deleted concurrently with the Stack object, as may occur in foreground deletion.  Otherwise the operator stays idle when it should reconcile.

A partial solution is to have the Stack controller watch for Workspace 'delete' events, since the controller is otherwise stuck waiting for the workspace to become ready. 

Or, the stack controller may have seen the workspace as ready, and proceeded to create an update for a non-existent workspace, which will not progress because the update controller waits for the workspace. 
 
Also: fix a flaky test.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
Closes #753 
