### PR TITLE
Ensure cleanup of Stack in foreground deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 
 - Stack Controller: watch for delete events. [#756](https://github.com/pulumi/pulumi-kubernetes-operator/pull/756)
 - Stack Controller: fix an issue where new commits weren't detected when using git sources. https://github.com/pulumi/pulumi-kubernetes-operator/issues/762
+- Ensure cleanup of Stack in foreground deletion. [#760](https://github.com/pulumi/pulumi-kubernetes-operator/pull/760)
 
 ## 2.0.0-beta.2 (2024-11-11)
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -197,7 +197,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller manager to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply --server-side=true -f -
+	$(KUSTOMIZE) build config/default | $(KUBECTL) apply --server-side=true --force-conflicts -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller manager from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/operator/internal/controller/auto/update_controller_test.go
+++ b/operator/internal/controller/auto/update_controller_test.go
@@ -163,7 +163,7 @@ func TestUpdate(t *testing.T) {
 				EndTime:   metav1.NewTime(time.Unix(0, 0).UTC()),
 				Conditions: []metav1.Condition{
 					{Type: "Progressing", Status: "False", Reason: "Complete"},
-					{Type: "Failed", Status: "False", Reason: "succeeded"},
+					{Type: "Failed", Status: "False", Reason: "UpdateSucceeded"},
 					{Type: "Complete", Status: "True", Reason: "Updated"},
 				},
 			},
@@ -206,7 +206,7 @@ func TestUpdate(t *testing.T) {
 					{
 						Type:    "Failed",
 						Status:  "True",
-						Reason:  "failed",
+						Reason:  "UpdateFailed",
 						Message: "something went wrong",
 					},
 					{Type: "Complete", Status: "True", Reason: "Updated"},
@@ -214,9 +214,7 @@ func TestUpdate(t *testing.T) {
 			},
 		},
 		{
-			// Auto API failures are currently returned as non-nil errors,
-			// which we translate into "failed" Results.
-			name: "update failed error",
+			name: "update grpc error",
 			obj:  autov1alpha1.Update{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "uid"}},
 			client: func(ctrl *gomock.Controller) upper {
 				upper := NewMockupper(ctrl)
@@ -234,19 +232,7 @@ func TestUpdate(t *testing.T) {
 				return upper
 			},
 			kclient: func(*gomock.Controller) creater { return nil },
-			want: autov1alpha1.UpdateStatus{
-				Message: "failed to run update: exit status 255",
-				Conditions: []metav1.Condition{
-					{Type: "Progressing", Status: "False", Reason: "Complete"},
-					{
-						Type:    "Failed",
-						Status:  "True",
-						Reason:  "Unknown",
-						Message: "failed to run update: exit status 255",
-					},
-					{Type: "Complete", Status: "True", Reason: "Complete"},
-				},
-			},
+			wantErr: "failed to run update: exit status 255",
 		},
 		{
 			name: "workspace grpc failure",

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -617,6 +617,10 @@ func (r *StackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 
 	// We can exit early if there is no clean-up to do.
 	if isStackMarkedToBeDeleted && !stack.DestroyOnFinalize {
+		instance.Status.MarkReadyCondition()
+		if err = saveStatus(); err != nil {
+			return reconcile.Result{}, err
+		}
 		if controllerutil.RemoveFinalizer(instance, pulumiFinalizer) {
 			return reconcile.Result{}, r.Update(ctx, instance, client.FieldOwner(FieldManager))
 		}

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -1535,7 +1535,9 @@ func (sess *stackReconcilerSession) setOwnerReferences(o *pulumiv1.Stack, update
 
 	// Set the stack as an owner of the update. Updates should survive deletion of the Workspace,
 	// to retain some history even if the workspace is deleted as an optimization.
-	if err := controllerutil.SetOwnerReference(o, update, sess.scheme); err != nil {
+	// The WithBlockOwnerDeletion option ensures that the owner reference is not removed eagerly in background deletion
+	// of the stack, which would break the EnqueueRequestForOwner logic that triggers a new reconcile loop.
+	if err := controllerutil.SetOwnerReference(o, update, sess.scheme, controllerutil.WithBlockOwnerDeletion(true)); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Problem

There's two edge cases where a Stack could become stuck in a deleting state, and this PR addresses both.  

1. A missing `Update` object. The stack controller processes the 'current update' (if any) before doing anything else.  The stack keeps the name of the current update in its status block, and performs a lookup of the named Update object to check its progress. If the update doesn't exist, it assumes a cache miss and simply requeues.  Let's imagine that the update was actually deleted, e.g. via cascading foreground delete.  In that case, the stack freezes up.
2. A missing `Workspace` object. The stack controller strictly handles workspace setup before kicking off an update, and doesn't re-create the workspace if it were to disappear while the update is in progress. If the workspace goes missing, e.g. due to foreground delete, then the Update blocks indefinitely and likewise does the Stack.  

An additional constraint is that completed `Update` objects serve as a useful historical record, and would ideally not be garbage-collected when the associated `Workspace` is deleted.  It is desirable that a user be able to delete an idle workspace, and one would not want to discard the history in that case.

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

1. Teach the stack controller to place a "stack" finalizer to the "current" `Update` object, to ensure that it doesn't disappear while a Stack is waiting for its completion.  Once complete, the finalizer is removed and the completed Update object is then targetable by a cleanup routine.
2. Be sure to save the status (which removes the finalizer as mentioned above) in the "fast path" deletion case.
3. Automatically abort an Update when it is deleted.
4. Automatically abort an Update when its managing workspace is deleted.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #753 
