### PR TITLE
Fix requeue for git commit tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## Unreleased
 
 - Stack Controller: watch for delete events. [#756](https://github.com/pulumi/pulumi-kubernetes-operator/pull/756)
+- Stack Controller: fix an issue where new commits weren't detected when using git sources. https://github.com/pulumi/pulumi-kubernetes-operator/issues/762
 
 ## 2.0.0-beta.2 (2024-11-11)
 

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -770,7 +770,11 @@ func (r *StackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 				// Reconcile every resyncFreq to check for new commits to the branch.
 				pollFreq := resyncFreq(instance)
 				log.Info("Commit hash unchanged. Will poll for new commits.", "pollFrequency", pollFreq)
-				requeueAfter = max(1*time.Second, min(pollFreq, requeueAfter))
+				if requeueAfter > 0 {
+					requeueAfter = max(1*time.Second, min(pollFreq, requeueAfter))
+				} else {
+					requeueAfter = max(1*time.Second, pollFreq)
+				}
 			} else {
 				log.Info("Commit hash unchanged.")
 			}

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -761,7 +761,7 @@ func (r *StackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 			requeueAfter = max(1*time.Second, time.Until(instance.Status.LastUpdate.LastResyncTime.Add(cooldown(instance))))
 		}
 		// Schedule another poll if ContinueResyncOnCommitMatch is set or if we're tracking a branch.
-		if sess.stack.ContinueResyncOnCommitMatch || stack.Branch != "" {
+		if sess.stack.ContinueResyncOnCommitMatch || (stack.GitSource != nil && stack.GitSource.Branch != "") {
 			requeueAfter = max(1*time.Second, time.Until(instance.Status.LastUpdate.LastResyncTime.Add(resyncFreq(instance))))
 		}
 		if stack.GitSource != nil {


### PR DESCRIPTION
Fixes a bug where we were accidentally cancelling a requeue when we intended to poll again after a minute.

Fixes https://github.com/pulumi/pulumi-kubernetes-operator/issues/762.