### PR TITLE
deployment template: fix extraSidecars indentation

### DIFF
--- a/deploy/helm/pulumi-operator/templates/deployment.yaml
+++ b/deploy/helm/pulumi-operator/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       {{- if .Values.extraSidecars }}
-      {{- toYaml .Values.extraSidecars  | nindent  8 }}
+      {{- toYaml .Values.extraSidecars  | nindent 6 }}
       {{- end}}
       - name: manager
         args:


### PR DESCRIPTION
### Proposed changes

In the deployment template, the `extraSidecars` object is indented too far, resulting in malformed YAML.

```yaml
# test-values.yaml
extraSidecars:
  - name: busy-beaver
    image: busybox
    command: ["sh", "-c"]
    args: ["sleep 999999"]
```

```sh
cd pulumi-kubernetes-operator/deploy/helm/pulumi-operator
helm template . -f test-values.yaml

Error: YAML parse error on pulumi-kubernetes-operator/templates/deployment.yaml: error converting YAML to JSON: yaml: line 34: did not find expected key
```

This change reduces the indentation to match the `manager` entry in the `containers` list.

### Notes

* Ideally this can be included in the 0.8.x release train as 2.x is still unreleased
* As far as I can tell, this has been an issue since the file was introduced in #379 
* Aside, the PR template has a reference to CONTRIBUTING.md, but that file doesn't seem to exist in the repo