### PR TITLE
Reduce volatility of the workspace due to ordering and caching issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## Unreleased
+
+- Reduce volatility of the workspace due to ordering and caching issues [#803](https://github.com/pulumi/pulumi-kubernetes-operator/pull/803)
+
 ## 2.0.0-beta.3 (2024-11-27)
 
 - Stack Controller: watch for delete events. [#756](https://github.com/pulumi/pulumi-kubernetes-operator/pull/756)


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

This PR fixes a problem w volatility of the workspace specification, as applied by the stack controller.  

One issue occurs when numerous config elements are present in the stack spec, because the controller iterates over a Go map and thus produces a volatile list. The controller is written such that it assumes that the patch operation is idempotent, and patches the workspace unconditionally when it thinks a workspace is needed.

To demonstrate the problem, when one watches the workspace, one sees volatility in the ordering of elements:
```
  stacks:
  - config:
    - key: clusterName
      secret: false
      value: pulumi-dev
    - key: domainName
      secret: false
      value: pulumi-dev.aws.pulumi.com
    - key: envName
      secret: false
      value: main
---
  stacks:
  - config:
    - key: envName
      secret: false
      value: main
    - key: clusterName
      secret: false
      value: pulumi-dev
    - key: domainName
      secret: false
      value: pulumi-dev.aws.pulumi.com
```

The other issue is related to the fact that controller uses a cache to evaluate whether to wait on an outstanding update, or whether to proceed to provision a workspace and start a new update. This PR adds a call to `saveStatus` to preserve idempotency. Notice that the code already does similarly before creating the update object.

I think that, with these two fixes, the stack controller will be more careful about when it mutates the workspace, and produce a more stable specification to avoid a spurious change to the generation.

### Note about the Workaround

It is not recommended that users suppress the `auto.pulumi.com/revision-hash` annotation, since the workspace controller uses it to drive pod replacement, and has certain expectations about that. Suppressing that behavior should be considered an unsupported usage.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #786
Closes #795