### PR TITLE
fix: do not delete workspace pod on authz errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 - Enable deleting workspace pod after a successful sync by exposing `WorkspaceReclaimPolicy` [#804](https://github.com/pulumi/pulumi-kubernetes-operator/pull/804)
 - Surface Update failures back to the Stack object status [#807](https://github.com/pulumi/pulumi-kubernetes-operator/pull/807)
 - Surface update conflict errors when a stack is locked [#807](https://github.com/pulumi/pulumi-kubernetes-operator/pull/807)4 (add changelog entry)
+- Do not destroy the workspace pod if an authentication error occurs [#805](https://github.com/pulumi/pulumi-kubernetes-operator/pull/805)
 
 ## 2.0.0-beta.3 (2024-11-27)
 

--- a/agent/pkg/server/pulumi_errors.go
+++ b/agent/pkg/server/pulumi_errors.go
@@ -31,6 +31,11 @@ var knownErrors = knownPulumiErrors{
 		Reason:  "UpdateConflict",
 		Code:    409,
 	},
+	"invalid access token": {
+		Message: "Invalid access token used to authenticate with Pulumi Cloud",
+		Reason:  "InvalidAccessToken",
+		Code:    401,
+	},
 }
 
 // withPulumiErrorInfo iterates over known errors and checks if the provided error matches any of them.

--- a/agent/pkg/server/server.go
+++ b/agent/pkg/server/server.go
@@ -175,7 +175,9 @@ func (s *Server) Cancel() {
 func (s *Server) WhoAmI(ctx context.Context, in *pb.WhoAmIRequest) (*pb.WhoAmIResult, error) {
 	whoami, err := s.ws.WhoAmIDetails(ctx)
 	if err != nil {
-		return nil, err
+		s.log.Errorw("whoami completed with an error", zap.Error(err))
+		st := status.Newf(codes.Unknown, "whoami failed: %v", err)
+		return nil, withPulumiErrorInfo(st, err).Err()
 	}
 	resp := &pb.WhoAmIResult{
 		User:          whoami.User,

--- a/operator/e2e/testdata/random-yaml-auth-error/manifests.yaml
+++ b/operator/e2e/testdata/random-yaml-auth-error/manifests.yaml
@@ -1,0 +1,89 @@
+---
+# This NetworkPolicy allows ingress traffic to the source-controller pods
+# from specific namespaces and pods managed by pulumi-kubernetes-operator.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-random-yaml-auth-error-fetch
+  namespace: flux-system
+spec:
+  podSelector:
+    matchLabels:
+      app: source-controller
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: http
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: random-yaml-auth-error
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/managed-by: pulumi-kubernetes-operator
+              app.kubernetes.io/name: pulumi
+              app.kubernetes.io/component: workspace
+  policyTypes:
+    - Ingress
+---
+# Namespace to isolate the random-yaml-auth-error test.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: random-yaml-auth-error
+---
+# ServiceAccount for the random-yaml-auth-error namespace.
+# No permissions are granted to this service account.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: random-yaml-auth-error
+  namespace: random-yaml-auth-error
+---
+# Define a Flux Source GitRepository object for syncing Pulumi examples from a GitHub repository
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: pulumi-examples
+  namespace: random-yaml-auth-error
+spec:
+  interval: 10m
+  ref:
+    branch: master
+  timeout: 60s
+  url: https://github.com/pulumi/examples
+---
+apiVersion: pulumi.com/v1
+kind: Stack
+metadata:
+  name: random-yaml-auth-error
+  namespace: random-yaml-auth-error
+spec:
+  fluxSource:
+    sourceRef:
+      apiVersion: source.toolkit.fluxcd.io/v1
+      kind: GitRepository
+      name: pulumi-examples
+    dir: random-yaml
+  stack: dev
+  refresh: false
+  continueResyncOnCommitMatch: false
+  resyncFrequencySeconds: 60
+  destroyOnFinalize: true
+  # Enable file state for testing.
+  envRefs:
+    PULUMI_BACKEND_URL:
+      type: Literal
+      literal:
+        value: "file:///state/"
+    PULUMI_CONFIG_PASSPHRASE:
+      type: Literal
+      literal:
+        value: "test"
+  workspaceTemplate:
+    spec:
+      serviceAccountName: random-yaml-auth-error
+      podTemplate:
+        spec:
+          containers:
+            - name: pulumi


### PR DESCRIPTION
### Proposed Changes  

This PR updates the workspace controller to run the grpc `WhoAmI` command before proceeding with reconciliation. This change helps surface authentication issues early in the process.  

If authentication fails, the workspace pod is retained rather than deleted, as it remains in a pristine state. This avoids unnecessary pod recreation and reduces the time required to spin up a new StatefulSet pod. Additionally, it prevents excessive workspace pod churn in the event of persistent authentication failures.  

#### Example Log Output on Authentication Failure  

```shell
2025-02-05T18:37:33.029Z	INFO	Applying StatefulSet	{"controller": "workspace-controller", "controllerGroup": "auto.pulumi.com", "controllerKind": "Workspace", "Workspace": {"name":"nginx-k8s-stack","namespace":"pulumi-kubernetes-operator"}, "namespace": "pulumi-kubernetes-operator", "name": "nginx-k8s-stack", "reconcileID": "bca83f73-73aa-4004-bce0-14aa8c4bf48a", "revision": "112271", "hash": "ec3e2de049a62cdb9a133f4c141df826", "source": {"Generation":1,"ForceRequest":"","Git":{"URL":"https://github.com/pulumi/examples","Ref":"4ce6027439cc8c9cc60f5704abc7d2204a07d98e","Dir":"/kubernetes-ts-nginx","Shallow":false,"SSHPrivateKey":null,"Username":null,"Password":null,"Token":null},"Flux":null,"Local":null}}
2025-02-05T18:37:33.151Z	INFO	Connecting to workspace pod	{"controller": "workspace-controller", "controllerGroup": "auto.pulumi.com", "controllerKind": "Workspace", "Workspace": {"name":"nginx-k8s-stack","namespace":"pulumi-kubernetes-operator"}, "namespace": "pulumi-kubernetes-operator", "name": "nginx-k8s-stack", "reconcileID": "bca83f73-73aa-4004-bce0-14aa8c4bf48a", "revision": "112271", "addr": "nginx-k8s-stack-workspace.pulumi-kubernetes-operator:50051"}
2025-02-05T18:37:33.158Z	INFO	Connected to workspace pod	{"controller": "workspace-controller", "controllerGroup": "auto.pulumi.com", "controllerKind": "Workspace", "Workspace": {"name":"nginx-k8s-stack","namespace":"pulumi-kubernetes-operator"}, "namespace": "pulumi-kubernetes-operator", "name": "nginx-k8s-stack", "reconcileID": "bca83f73-73aa-4004-bce0-14aa8c4bf48a", "revision": "112271", "addr": "nginx-k8s-stack-workspace.pulumi-kubernetes-operator:50051"}
2025-02-05T18:37:33.158Z	INFO	Running whoami to ensure authentication is setup correctly with the workspace pod	{"controller": "workspace-controller", "controllerGroup": "auto.pulumi.com", "controllerKind": "Workspace", "Workspace": {"name":"nginx-k8s-stack","namespace":"pulumi-kubernetes-operator"}, "namespace": "pulumi-kubernetes-operator", "name": "nginx-k8s-stack", "reconcileID": "bca83f73-73aa-4004-bce0-14aa8c4bf48a", "revision": "112271"}
2025-02-05T18:37:33.164Z	ERROR	unable to authenticate; retaining the workspace pod to retry later	{"controller": "workspace-controller", "controllerGroup": "auto.pulumi.com", "controllerKind": "Workspace", "Workspace": {"name":"nginx-k8s-stack","namespace":"pulumi-kubernetes-operator"}, "namespace": "pulumi-kubernetes-operator", "name": "nginx-k8s-stack", "reconcileID": "bca83f73-73aa-4004-bce0-14aa8c4bf48a", "revision": "112271", "error": "rpc error: code = Unauthenticated desc = TokenReview API is unavailable"}
...
2025-02-05T18:37:33.176Z	INFO	Status updated	{"controller": "workspace-controller", "controllerGroup": "auto.pulumi.com", "controllerKind": "Workspace", "Workspace": {"name":"nginx-k8s-stack","namespace":"pulumi-kubernetes-operator"}, "namespace": "pulumi-kubernetes-operator", "name": "nginx-k8s-stack", "reconcileID": "bca83f73-73aa-4004-bce0-14aa8c4bf48a", "revision": "112336", "observedGeneration": 1, "address": "nginx-k8s-stack-workspace.pulumi-kubernetes-operator:50051", "conditions": [{"type":"Ready","status":"False","observedGeneration":1,"lastTransitionTime":"2025-02-05T18:37:12Z","reason":"AuthenticationFailed","message":"Unable to authenticate with the workspace pod."}]}
```

#### Stored Workspace Status  

When the wrong Pulumi Access token is provided:
```yaml
status:
  address: nginx-stack-workspace.default:50051
  conditions:
  - lastTransitionTime: "2025-02-07T23:34:13Z"
    message: Invalid access token used to authenticate with Pulumi Cloud
    observedGeneration: 1
    reason: InvalidAccessToken
    status: "False"
    type: Ready
  observedGeneration: 1
```

When there is a K8s auth issue:
```yaml
status:
  address: nginx-stack-workspace.default:50051
  conditions:
  - lastTransitionTime: "2025-02-07T23:34:13Z"
    message: TokenReview API is unavailable
    observedGeneration: 2
    reason: Unauthenticated
    status: "False"
    type: Ready
  observedGeneration: 2
```

### Testing  

- Added an end-to-end (e2e) test to verify that the workspace pod is not deleted when authentication fails.  
- Manually validated on a GKE cluster.  

### Related Issues (Optional)  

Fixes: #740