### PR TITLE
Enable setting the log verbosity level of Pulumi CLI for a stack/workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 - Garbage collection for Update objects. [#810](https://github.com/pulumi/pulumi-kubernetes-operator/pull/810)
 - Use correct logic for OwnerReferencesChangedPredicate. [#815](https://github.com/pulumi/pulumi-kubernetes-operator/pull/815)
 - Use audience-scoped access token. [#816](https://github.com/pulumi/pulumi-kubernetes-operator/pull/816)
+- Enable setting the log verbosity of Pulumi CLI operations for a given workspace. [#824](https://github.com/pulumi/pulumi-kubernetes-operator/pull/824)
 
 ## 2.0.0-beta.3 (2024-11-27)
 

--- a/agent/cmd/serve.go
+++ b/agent/cmd/serve.go
@@ -51,6 +51,7 @@ var (
 	_audiences          []string
 	_workspaceNamespace string
 	_workspaceName      string
+	_pulumiLogLevel     uint
 )
 
 // serveCmd represents the serve command
@@ -156,7 +157,8 @@ var serveCmd = &cobra.Command{
 
 		// Create the automation service
 		autoServer, err := server.NewServer(ctx, workspace, &server.Options{
-			StackName: _stack,
+			StackName:      _stack,
+			PulumiLogLevel: _pulumiLogLevel,
 		})
 		if err != nil {
 			return fmt.Errorf("unable to make an automation server: %w", err)
@@ -218,4 +220,5 @@ func init() {
 	serveCmd.Flags().StringArrayVar(&_audiences, "kube-audience", nil, "The audience to expect in the token (for kubernetes auth mode)")
 	serveCmd.Flags().StringVar(&_workspaceNamespace, "kube-workspace-namespace", os.Getenv("WORKSPACE_NAMESPACE"), "The Workspace object namespace (for kubernetes auth mode)")
 	serveCmd.Flags().StringVar(&_workspaceName, "kube-workspace-name", os.Getenv("WORKSPACE_NAME"), "The Workspace object name (for kubernetes auth mode)")
+	serveCmd.Flags().UintVar(&_pulumiLogLevel, "pulumi-log-level", 0, "The level of logging to use for the Pulumi CLI")
 }

--- a/agent/pkg/server/server.go
+++ b/agent/pkg/server/server.go
@@ -347,7 +347,7 @@ func (s *Server) Preview(in *pb.PreviewRequest, srv pb.AutomationService_Preview
 	opts := []optpreview.Option{
 		optpreview.UserAgent(_userAgent),
 		optpreview.Diff(), /* richer result? */
-		optpreview.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel}),
+		optpreview.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel, LogToStdErr: true}),
 	}
 	if in.Parallel != nil {
 		opts = append(opts, optpreview.Parallel(int(*in.Parallel)))
@@ -440,7 +440,7 @@ func (s *Server) Refresh(in *pb.RefreshRequest, srv pb.AutomationService_Refresh
 	// determine the options to pass to the preview operation
 	opts := []optrefresh.Option{
 		optrefresh.UserAgent(_userAgent),
-		optrefresh.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel}),
+		optrefresh.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel, LogToStdErr: true}),
 	}
 	if in.Parallel != nil {
 		opts = append(opts, optrefresh.Parallel(int(*in.Parallel)))
@@ -523,7 +523,7 @@ func (s *Server) Up(in *pb.UpRequest, srv pb.AutomationService_UpServer) error {
 		optup.UserAgent(_userAgent),
 		optup.SuppressProgress(),
 		optup.Diff(), /* richer result? */
-		optup.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel}),
+		optup.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel, LogToStdErr: true}),
 	}
 	if in.Parallel != nil {
 		opts = append(opts, optup.Parallel(int(*in.Parallel)))
@@ -628,7 +628,7 @@ func (s *Server) Destroy(in *pb.DestroyRequest, srv pb.AutomationService_Destroy
 	// determine the options to pass to the preview operation
 	opts := []optdestroy.Option{
 		optdestroy.UserAgent(_userAgent),
-		optdestroy.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel}),
+		optdestroy.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel, LogToStdErr: true}),
 	}
 	if in.Parallel != nil {
 		opts = append(opts, optdestroy.Parallel(int(*in.Parallel)))

--- a/agent/pkg/server/server.go
+++ b/agent/pkg/server/server.go
@@ -347,7 +347,11 @@ func (s *Server) Preview(in *pb.PreviewRequest, srv pb.AutomationService_Preview
 	opts := []optpreview.Option{
 		optpreview.UserAgent(_userAgent),
 		optpreview.Diff(), /* richer result? */
-		optpreview.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel, LogToStdErr: true}),
+	}
+	if s.pulumiLogLevel > 0 {
+		// We need to conidtionally enable debug logging as upstream pu/pu will set the log level to be
+		// at least 1 if debug.LoggingOptions is not nil.
+		opts = append(opts, optpreview.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel, LogToStdErr: true}))
 	}
 	if in.Parallel != nil {
 		opts = append(opts, optpreview.Parallel(int(*in.Parallel)))
@@ -440,7 +444,11 @@ func (s *Server) Refresh(in *pb.RefreshRequest, srv pb.AutomationService_Refresh
 	// determine the options to pass to the preview operation
 	opts := []optrefresh.Option{
 		optrefresh.UserAgent(_userAgent),
-		optrefresh.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel, LogToStdErr: true}),
+	}
+	if s.pulumiLogLevel > 0 {
+		// We need to conidtionally enable debug logging as upstream pu/pu will set the log level to be
+		// at least 1 if debug.LoggingOptions is not nil.
+		opts = append(opts, optrefresh.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel, LogToStdErr: true}))
 	}
 	if in.Parallel != nil {
 		opts = append(opts, optrefresh.Parallel(int(*in.Parallel)))
@@ -523,7 +531,11 @@ func (s *Server) Up(in *pb.UpRequest, srv pb.AutomationService_UpServer) error {
 		optup.UserAgent(_userAgent),
 		optup.SuppressProgress(),
 		optup.Diff(), /* richer result? */
-		optup.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel, LogToStdErr: true}),
+	}
+	if s.pulumiLogLevel > 0 {
+		// We need to conidtionally enable debug logging as upstream pu/pu will set the log level to be
+		// at least 1 if debug.LoggingOptions is not nil.
+		opts = append(opts, optup.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel, LogToStdErr: true}))
 	}
 	if in.Parallel != nil {
 		opts = append(opts, optup.Parallel(int(*in.Parallel)))
@@ -628,7 +640,11 @@ func (s *Server) Destroy(in *pb.DestroyRequest, srv pb.AutomationService_Destroy
 	// determine the options to pass to the preview operation
 	opts := []optdestroy.Option{
 		optdestroy.UserAgent(_userAgent),
-		optdestroy.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel, LogToStdErr: true}),
+	}
+	if s.pulumiLogLevel > 0 {
+		// We need to conidtionally enable debug logging as upstream pu/pu will set the log level to be
+		// at least 1 if debug.LoggingOptions is not nil.
+		opts = append(opts, optdestroy.DebugLogging(debug.LoggingOptions{LogLevel: &s.pulumiLogLevel, LogToStdErr: true}))
 	}
 	if in.Parallel != nil {
 		opts = append(opts, optdestroy.Parallel(int(*in.Parallel)))

--- a/agent/pkg/server/server_test.go
+++ b/agent/pkg/server/server_test.go
@@ -479,6 +479,7 @@ func TestUp(t *testing.T) {
 		name       string
 		projectDir string
 		stacks     []string
+		serverOpts *Options
 		req        *pb.UpRequest
 		wantErr    any
 		want       auto.ConfigMap
@@ -496,13 +497,20 @@ func TestUp(t *testing.T) {
 			stacks:     []string{TestStackName},
 			req:        &pb.UpRequest{},
 		},
+		{
+			name:       "Pulumi CLI verbose logging enabled: lvl 11",
+			projectDir: "./testdata/simple",
+			stacks:     []string{TestStackName},
+			serverOpts: &Options{PulumiLogLevel: 11},
+			req:        &pb.UpRequest{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			g := gomega.NewWithT(t)
 			ctx := newContext(t)
-			tc := newTC(ctx, t, tcOptions{ProjectDir: tt.projectDir, Stacks: tt.stacks})
+			tc := newTC(ctx, t, tcOptions{ProjectDir: tt.projectDir, Stacks: tt.stacks, ServerOpts: tt.serverOpts})
 
 			srv := &upStream{
 				ctx:    ctx,
@@ -517,6 +525,11 @@ func TestUp(t *testing.T) {
 				g.Expect(srv.result).ToNot(gomega.BeNil())
 				g.Expect(srv.result.Summary).ToNot(gomega.BeNil())
 				g.Expect(srv.result.Summary.Result).To(gomega.Equal("succeeded"))
+
+				if tt.serverOpts != nil {
+					// ensure that the extra logs are present
+					g.Expect(srv.result).To(gomega.ContainSubstring("log level 11 will print sensitive information"))
+				}
 			}
 		})
 	}
@@ -556,6 +569,7 @@ func TestPreview(t *testing.T) {
 		projectDir string
 		stacks     []string
 		req        *pb.PreviewRequest
+		serverOpts *Options
 		wantErr    any
 		want       auto.ConfigMap
 	}{
@@ -572,13 +586,20 @@ func TestPreview(t *testing.T) {
 			stacks:     []string{TestStackName},
 			req:        &pb.PreviewRequest{},
 		},
+		{
+			name:       "Pulumi CLI verbose logging enabled",
+			projectDir: "./testdata/simple",
+			stacks:     []string{TestStackName},
+			serverOpts: &Options{PulumiLogLevel: 11},
+			req:        &pb.PreviewRequest{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			g := gomega.NewWithT(t)
 			ctx := newContext(t)
-			tc := newTC(ctx, t, tcOptions{ProjectDir: tt.projectDir, Stacks: tt.stacks})
+			tc := newTC(ctx, t, tcOptions{ProjectDir: tt.projectDir, Stacks: tt.stacks, ServerOpts: tt.serverOpts})
 
 			srv := &previewStream{
 				ctx:    ctx,
@@ -591,6 +612,11 @@ func TestPreview(t *testing.T) {
 				g.Expect(err).ToNot(gomega.HaveOccurred())
 				g.Expect(srv.events).ToNot(gomega.BeEmpty())
 				g.Expect(srv.result).ToNot(gomega.BeNil())
+
+				if tt.serverOpts != nil {
+					// ensure that the extra logs are present
+					g.Expect(srv.result).To(gomega.ContainSubstring("log level 11 will print sensitive information"))
+				}
 			}
 		})
 	}
@@ -630,6 +656,7 @@ func TestRefresh(t *testing.T) {
 		projectDir string
 		stacks     []string
 		req        *pb.RefreshRequest
+		serverOpts *Options
 		wantErr    any
 		want       auto.ConfigMap
 	}{
@@ -646,13 +673,20 @@ func TestRefresh(t *testing.T) {
 			stacks:     []string{TestStackName},
 			req:        &pb.RefreshRequest{},
 		},
+		{
+			name:       "Pulumi CLI verbose logging enabled",
+			projectDir: "./testdata/simple",
+			stacks:     []string{TestStackName},
+			serverOpts: &Options{PulumiLogLevel: 11},
+			req:        &pb.RefreshRequest{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			g := gomega.NewWithT(t)
 			ctx := newContext(t)
-			tc := newTC(ctx, t, tcOptions{ProjectDir: tt.projectDir, Stacks: tt.stacks})
+			tc := newTC(ctx, t, tcOptions{ProjectDir: tt.projectDir, Stacks: tt.stacks, ServerOpts: tt.serverOpts})
 
 			srv := &refreshStream{
 				ctx:    ctx,
@@ -667,6 +701,11 @@ func TestRefresh(t *testing.T) {
 				g.Expect(srv.result).ToNot(gomega.BeNil())
 				g.Expect(srv.result.Summary).ToNot(gomega.BeNil())
 				g.Expect(srv.result.Summary.Result).To(gomega.Equal("succeeded"))
+
+				if tt.serverOpts != nil {
+					// ensure that the extra logs are present
+					g.Expect(srv.result).To(gomega.ContainSubstring("log level 11 will print sensitive information"))
+				}
 			}
 		})
 	}
@@ -706,6 +745,7 @@ func TestDestroy(t *testing.T) {
 		projectDir string
 		stacks     []string
 		req        *pb.DestroyRequest
+		serverOpts *Options
 		wantErr    any
 		want       auto.ConfigMap
 	}{
@@ -720,6 +760,13 @@ func TestDestroy(t *testing.T) {
 			name:       "simple",
 			projectDir: "./testdata/simple",
 			stacks:     []string{TestStackName},
+			req:        &pb.DestroyRequest{},
+		},
+		{
+			name:       "Pulumi CLI verbose logging enabled",
+			projectDir: "./testdata/simple",
+			stacks:     []string{TestStackName},
+			serverOpts: &Options{PulumiLogLevel: 11},
 			req:        &pb.DestroyRequest{},
 		},
 	}

--- a/deploy/crds/auto.pulumi.com_workspaces.yaml
+++ b/deploy/crds/auto.pulumi.com_workspaces.yaml
@@ -8454,6 +8454,14 @@ spec:
                     - containers
                     type: object
                 type: object
+              pulumiLogLevel:
+                description: |-
+                  PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
+                  If unset,verbose logging is disabled.
+                  See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
+                  for more information about log levels.
+                format: int32
+                type: integer
               resources:
                 description: |-
                   Compute Resources required by this workspace.

--- a/deploy/crds/pulumi.com_stacks.yaml
+++ b/deploy/crds/pulumi.com_stacks.yaml
@@ -9381,6 +9381,9 @@ spec:
                             - containers
                             type: object
                         type: object
+                      pulumiLogLevel:
+                        format: int32
+                        type: integer
                       resources:
                         description: ResourceRequirements describes the compute resource
                           requirements.
@@ -19017,6 +19020,9 @@ spec:
                             - containers
                             type: object
                         type: object
+                      pulumiLogLevel:
+                        format: int32
+                        type: integer
                       resources:
                         description: ResourceRequirements describes the compute resource
                           requirements.

--- a/deploy/crds/pulumi.com_stacks.yaml
+++ b/deploy/crds/pulumi.com_stacks.yaml
@@ -628,6 +628,14 @@ spec:
                 description: ProjectRepo is the git source control repository from
                   which we fetch the project code and configuration.
                 type: string
+              pulumiLogLevel:
+                description: |-
+                  (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
+                  If unset,verbose logging is disabled.
+                  See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
+                  for more information about log levels.
+                format: int32
+                type: integer
               refresh:
                 description: (optional) Refresh can be set to true to refresh the
                   stack before it is updated.
@@ -10264,6 +10272,14 @@ spec:
                 description: ProjectRepo is the git source control repository from
                   which we fetch the project code and configuration.
                 type: string
+              pulumiLogLevel:
+                description: |-
+                  (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
+                  If unset,verbose logging is disabled.
+                  See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
+                  for more information about log levels.
+                format: int32
+                type: integer
               refresh:
                 description: (optional) Refresh can be set to true to refresh the
                   stack before it is updated.

--- a/deploy/crds/pulumi.com_stacks.yaml
+++ b/deploy/crds/pulumi.com_stacks.yaml
@@ -628,14 +628,6 @@ spec:
                 description: ProjectRepo is the git source control repository from
                   which we fetch the project code and configuration.
                 type: string
-              pulumiLogLevel:
-                description: |-
-                  (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
-                  If unset,verbose logging is disabled.
-                  See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
-                  for more information about log levels.
-                format: int32
-                type: integer
               refresh:
                 description: (optional) Refresh can be set to true to refresh the
                   stack before it is updated.
@@ -10272,14 +10264,6 @@ spec:
                 description: ProjectRepo is the git source control repository from
                   which we fetch the project code and configuration.
                 type: string
-              pulumiLogLevel:
-                description: |-
-                  (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
-                  If unset,verbose logging is disabled.
-                  See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
-                  for more information about log levels.
-                format: int32
-                type: integer
               refresh:
                 description: (optional) Refresh can be set to true to refresh the
                   stack before it is updated.

--- a/deploy/helm/pulumi-operator/crds/auto.pulumi.com_workspaces.yaml
+++ b/deploy/helm/pulumi-operator/crds/auto.pulumi.com_workspaces.yaml
@@ -8454,6 +8454,14 @@ spec:
                     - containers
                     type: object
                 type: object
+              pulumiLogLevel:
+                description: |-
+                  PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
+                  If unset,verbose logging is disabled.
+                  See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
+                  for more information about log levels.
+                format: int32
+                type: integer
               resources:
                 description: |-
                   Compute Resources required by this workspace.

--- a/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
+++ b/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
@@ -9381,6 +9381,9 @@ spec:
                             - containers
                             type: object
                         type: object
+                      pulumiLogLevel:
+                        format: int32
+                        type: integer
                       resources:
                         description: ResourceRequirements describes the compute resource
                           requirements.
@@ -19017,6 +19020,9 @@ spec:
                             - containers
                             type: object
                         type: object
+                      pulumiLogLevel:
+                        format: int32
+                        type: integer
                       resources:
                         description: ResourceRequirements describes the compute resource
                           requirements.

--- a/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
+++ b/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
@@ -628,6 +628,14 @@ spec:
                 description: ProjectRepo is the git source control repository from
                   which we fetch the project code and configuration.
                 type: string
+              pulumiLogLevel:
+                description: |-
+                  (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
+                  If unset,verbose logging is disabled.
+                  See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
+                  for more information about log levels.
+                format: int32
+                type: integer
               refresh:
                 description: (optional) Refresh can be set to true to refresh the
                   stack before it is updated.
@@ -10264,6 +10272,14 @@ spec:
                 description: ProjectRepo is the git source control repository from
                   which we fetch the project code and configuration.
                 type: string
+              pulumiLogLevel:
+                description: |-
+                  (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
+                  If unset,verbose logging is disabled.
+                  See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
+                  for more information about log levels.
+                format: int32
+                type: integer
               refresh:
                 description: (optional) Refresh can be set to true to refresh the
                   stack before it is updated.

--- a/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
+++ b/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
@@ -628,14 +628,6 @@ spec:
                 description: ProjectRepo is the git source control repository from
                   which we fetch the project code and configuration.
                 type: string
-              pulumiLogLevel:
-                description: |-
-                  (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
-                  If unset,verbose logging is disabled.
-                  See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
-                  for more information about log levels.
-                format: int32
-                type: integer
               refresh:
                 description: (optional) Refresh can be set to true to refresh the
                   stack before it is updated.
@@ -10272,14 +10264,6 @@ spec:
                 description: ProjectRepo is the git source control repository from
                   which we fetch the project code and configuration.
                 type: string
-              pulumiLogLevel:
-                description: |-
-                  (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
-                  If unset,verbose logging is disabled.
-                  See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
-                  for more information about log levels.
-                format: int32
-                type: integer
               refresh:
                 description: (optional) Refresh can be set to true to refresh the
                   stack before it is updated.

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -255,18 +255,6 @@ re-evaluated before running a stack that depends on it.<br/>
         </td>
         <td>false</td>
       </tr><tr>
-        <td><b>pulumiLogLevel</b></td>
-        <td>integer</td>
-        <td>
-          (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
-If unset,verbose logging is disabled.
-See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
-for more information about log levels.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
         <td><b>refresh</b></td>
         <td>boolean</td>
         <td>
@@ -19699,18 +19687,6 @@ re-evaluated before running a stack that depends on it.<br/>
         <td>string</td>
         <td>
           ProjectRepo is the git source control repository from which we fetch the project code and configuration.<br/>
-        </td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>pulumiLogLevel</b></td>
-        <td>integer</td>
-        <td>
-          (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
-If unset,verbose logging is disabled.
-See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
-for more information about log levels.<br/>
-          <br/>
-            <i>Format</i>: int32<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -255,6 +255,18 @@ re-evaluated before running a stack that depends on it.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>pulumiLogLevel</b></td>
+        <td>integer</td>
+        <td>
+          (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
+If unset,verbose logging is disabled.
+See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
+for more information about log levels.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>refresh</b></td>
         <td>boolean</td>
         <td>
@@ -19687,6 +19699,18 @@ re-evaluated before running a stack that depends on it.<br/>
         <td>string</td>
         <td>
           ProjectRepo is the git source control repository from which we fetch the project code and configuration.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>pulumiLogLevel</b></td>
+        <td>integer</td>
+        <td>
+          (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
+If unset,verbose logging is disabled.
+See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
+for more information about log levels.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -2281,6 +2281,15 @@ with apply.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>pulumiLogLevel</b></td>
+        <td>integer</td>
+        <td>
+          <br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#stackspecworkspacetemplatespecresources">resources</a></b></td>
         <td>object</td>
         <td>
@@ -21713,6 +21722,15 @@ with apply.<br/>
         <td>
           EmbeddedPodTemplateSpecApplyConfiguration represents a declarative configuration of the EmbeddedPodTemplateSpec type for use
 with apply.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>pulumiLogLevel</b></td>
+        <td>integer</td>
+        <td>
+          <br/>
+          <br/>
+            <i>Format</i>: int32<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -151,6 +151,18 @@ More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>pulumiLogLevel</b></td>
+        <td>integer</td>
+        <td>
+          PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
+If unset,verbose logging is disabled.
+See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
+for more information about log levels.<br/>
+          <br/>
+            <i>Format</i>: int32<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#workspacespecresources">resources</a></b></td>
         <td>object</td>
         <td>

--- a/operator/api/auto/v1alpha1/workspace_types.go
+++ b/operator/api/auto/v1alpha1/workspace_types.go
@@ -101,6 +101,13 @@ type WorkspaceSpec struct {
 	// +optional
 	PodTemplate *EmbeddedPodTemplateSpec `json:"podTemplate,omitempty"`
 
+	// PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
+	// If unset,verbose logging is disabled.
+	// See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
+	// for more information about log levels.
+	// +optional
+	PulumiLogVerbosity uint32 `json:"pulumiLogLevel,omitempty"`
+
 	// List of stacks this workspace manages.
 	// +optional
 	// +patchMergeKey=name

--- a/operator/api/pulumi/shared/stack_types.go
+++ b/operator/api/pulumi/shared/stack_types.go
@@ -159,13 +159,6 @@ type StackSpec struct {
 	// The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
 	// +optional
 	WorkspaceReclaimPolicy WorkspaceReclaimPolicy `json:"workspaceReclaimPolicy,omitempty"`
-
-	// (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
-	// If unset,verbose logging is disabled.
-	// See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
-	// for more information about log levels.
-	// +optional
-	PulumiLogVerbosity uint32 `json:"pulumiLogLevel,omitempty"`
 }
 
 // GitSource specifies how to fetch from a git repository directly.

--- a/operator/api/pulumi/shared/stack_types.go
+++ b/operator/api/pulumi/shared/stack_types.go
@@ -159,6 +159,13 @@ type StackSpec struct {
 	// The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
 	// +optional
 	WorkspaceReclaimPolicy WorkspaceReclaimPolicy `json:"workspaceReclaimPolicy,omitempty"`
+
+	// (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
+	// If unset,verbose logging is disabled.
+	// See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
+	// for more information about log levels.
+	// +optional
+	PulumiLogVerbosity uint32 `json:"pulumiLogLevel,omitempty"`
 }
 
 // GitSource specifies how to fetch from a git repository directly.

--- a/operator/config/crd/bases/auto.pulumi.com_workspaces.yaml
+++ b/operator/config/crd/bases/auto.pulumi.com_workspaces.yaml
@@ -8454,6 +8454,14 @@ spec:
                     - containers
                     type: object
                 type: object
+              pulumiLogLevel:
+                description: |-
+                  PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
+                  If unset,verbose logging is disabled.
+                  See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
+                  for more information about log levels.
+                format: int32
+                type: integer
               resources:
                 description: |-
                   Compute Resources required by this workspace.

--- a/operator/config/crd/bases/pulumi.com_stacks.yaml
+++ b/operator/config/crd/bases/pulumi.com_stacks.yaml
@@ -9381,6 +9381,9 @@ spec:
                             - containers
                             type: object
                         type: object
+                      pulumiLogLevel:
+                        format: int32
+                        type: integer
                       resources:
                         description: ResourceRequirements describes the compute resource
                           requirements.
@@ -19017,6 +19020,9 @@ spec:
                             - containers
                             type: object
                         type: object
+                      pulumiLogLevel:
+                        format: int32
+                        type: integer
                       resources:
                         description: ResourceRequirements describes the compute resource
                           requirements.

--- a/operator/config/crd/bases/pulumi.com_stacks.yaml
+++ b/operator/config/crd/bases/pulumi.com_stacks.yaml
@@ -628,6 +628,14 @@ spec:
                 description: ProjectRepo is the git source control repository from
                   which we fetch the project code and configuration.
                 type: string
+              pulumiLogLevel:
+                description: |-
+                  (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
+                  If unset,verbose logging is disabled.
+                  See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
+                  for more information about log levels.
+                format: int32
+                type: integer
               refresh:
                 description: (optional) Refresh can be set to true to refresh the
                   stack before it is updated.
@@ -10264,6 +10272,14 @@ spec:
                 description: ProjectRepo is the git source control repository from
                   which we fetch the project code and configuration.
                 type: string
+              pulumiLogLevel:
+                description: |-
+                  (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
+                  If unset,verbose logging is disabled.
+                  See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
+                  for more information about log levels.
+                format: int32
+                type: integer
               refresh:
                 description: (optional) Refresh can be set to true to refresh the
                   stack before it is updated.

--- a/operator/config/crd/bases/pulumi.com_stacks.yaml
+++ b/operator/config/crd/bases/pulumi.com_stacks.yaml
@@ -628,14 +628,6 @@ spec:
                 description: ProjectRepo is the git source control repository from
                   which we fetch the project code and configuration.
                 type: string
-              pulumiLogLevel:
-                description: |-
-                  (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
-                  If unset,verbose logging is disabled.
-                  See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
-                  for more information about log levels.
-                format: int32
-                type: integer
               refresh:
                 description: (optional) Refresh can be set to true to refresh the
                   stack before it is updated.
@@ -10272,14 +10264,6 @@ spec:
                 description: ProjectRepo is the git source control repository from
                   which we fetch the project code and configuration.
                 type: string
-              pulumiLogLevel:
-                description: |-
-                  (optional) PulumiLogVerbosity is the log verbosity level to use for the Pulumi CLI.
-                  If unset,verbose logging is disabled.
-                  See: https://www.pulumi.com/docs/iac/support/troubleshooting/#verbose-logging
-                  for more information about log levels.
-                format: int32
-                type: integer
               refresh:
                 description: (optional) Refresh can be set to true to refresh the
                   stack before it is updated.

--- a/operator/internal/apply/auto/v1alpha1/workspacespec.go
+++ b/operator/internal/apply/auto/v1alpha1/workspacespec.go
@@ -35,6 +35,7 @@ type WorkspaceSpecApplyConfiguration struct {
 	Env                []v1.EnvVar                                `json:"env,omitempty"`
 	Resources          *v1.ResourceRequirements                   `json:"resources,omitempty"`
 	PodTemplate        *EmbeddedPodTemplateSpecApplyConfiguration `json:"podTemplate,omitempty"`
+	PulumiLogVerbosity *uint32                                    `json:"pulumiLogLevel,omitempty"`
 	Stacks             []WorkspaceStackApplyConfiguration         `json:"stacks,omitempty"`
 }
 
@@ -133,6 +134,14 @@ func (b *WorkspaceSpecApplyConfiguration) WithResources(value v1.ResourceRequire
 // If called multiple times, the PodTemplate field is set to the value of the last call.
 func (b *WorkspaceSpecApplyConfiguration) WithPodTemplate(value *EmbeddedPodTemplateSpecApplyConfiguration) *WorkspaceSpecApplyConfiguration {
 	b.PodTemplate = value
+	return b
+}
+
+// WithPulumiLogVerbosity sets the PulumiLogVerbosity field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PulumiLogVerbosity field is set to the value of the last call.
+func (b *WorkspaceSpecApplyConfiguration) WithPulumiLogVerbosity(value uint32) *WorkspaceSpecApplyConfiguration {
+	b.PulumiLogVerbosity = &value
 	return b
 }
 

--- a/operator/internal/controller/auto/workspace_controller.go
+++ b/operator/internal/controller/auto/workspace_controller.go
@@ -492,6 +492,11 @@ func newStatefulSet(ctx context.Context, w *autov1alpha1.Workspace, source *sour
 		"--kube-workspace-namespace", w.Namespace,
 		"--kube-workspace-name", w.Name)
 
+	// increase Pulumi CLI log verbosity if provided
+	if w.Spec.PulumiLogVerbosity != 0 {
+		command = append(command, "--pulumi-log-level", strconv.Itoa(int(w.Spec.PulumiLogVerbosity)))
+	}
+
 	statefulset := &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StatefulSet",

--- a/operator/internal/controller/auto/workspace_controller_test.go
+++ b/operator/internal/controller/auto/workspace_controller_test.go
@@ -413,6 +413,40 @@ var _ = Describe("Workspace Controller", func() {
 				Expect(pulumi.VolumeMounts).To(ConsistOf(HaveField("Name", "share"), HaveField("Name", "test")))
 			})
 		})
+
+		Describe("spec.pulumiLogVerbosity", func() {
+			When("pulumiLogVerbosity is set", func() {
+				BeforeEach(func(ctx context.Context) {
+					obj.Spec.PulumiLogVerbosity = 11
+				})
+
+				It("spins up the workspace pod with verbose logging for Pulumi CLI operations", func(ctx context.Context) {
+					_, err := reconcileF(ctx)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ss.Spec.Template.Spec.Containers).
+						To(
+							ConsistOf(
+								HaveField("Command", ContainElement("--pulumi-log-level")),
+							))
+				})
+			})
+
+			When("pulumiLogVerbosity is not set", func() {
+				BeforeEach(func(ctx context.Context) {
+					obj.Spec.PulumiLogVerbosity = 0 // Set to default value
+				})
+
+				It("spins up the workspace pod without verbose logging for Pulumi CLI operations", func(ctx context.Context) {
+					_, err := reconcileF(ctx)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ss.Spec.Template.Spec.Containers).
+						ToNot(
+							ConsistOf(
+								HaveField("Command", ContainElement("--pulumi-log-level")),
+							))
+				})
+			})
+		})
 	})
 
 	Describe("Agent Injection", func() {

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -1355,6 +1355,12 @@ func (sess *stackReconcilerSession) NewWorkspace(stack *pulumiv1.Stack) error {
 		},
 	}
 	sess.wspc = &sess.ws.Spec.PodTemplate.Spec.Containers[0]
+
+	// Propagate Pulumi CLI log verbosity setting to the workspace.
+	if stack.Spec.PulumiLogVerbosity != 0 {
+		sess.ws.Spec.PulumiLogVerbosity = stack.Spec.PulumiLogVerbosity
+	}
+
 	if err := controllerutil.SetControllerReference(stack, sess.ws, sess.scheme); err != nil {
 		return err
 	}

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -1356,11 +1356,6 @@ func (sess *stackReconcilerSession) NewWorkspace(stack *pulumiv1.Stack) error {
 	}
 	sess.wspc = &sess.ws.Spec.PodTemplate.Spec.Containers[0]
 
-	// Propagate Pulumi CLI log verbosity setting to the workspace.
-	if stack.Spec.PulumiLogVerbosity != 0 {
-		sess.ws.Spec.PulumiLogVerbosity = stack.Spec.PulumiLogVerbosity
-	}
-
 	if err := controllerutil.SetControllerReference(stack, sess.ws, sess.scheme); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Proposed changes

This PR adds a new optional Stack spec field: `PulumiLogVerbosity`. This field determines the log verbosity level of pulumi up/down/refresh operations.

### Related issues (optional)

Closes: #823