### PR TITLE
fix: do not delete the workspace pod when the last update failed

### DIFF
--- a/deploy/crds/pulumi.com_stacks.yaml
+++ b/deploy/crds/pulumi.com_stacks.yaml
@@ -773,7 +773,8 @@ spec:
                 type: boolean
               workspaceReclaimPolicy:
                 description: |-
-                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is synced.
+                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
+                  successfully synced, and the last update is in a succeeded state.
                   The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
                 enum:
                 - Retain
@@ -10409,7 +10410,8 @@ spec:
                 type: boolean
               workspaceReclaimPolicy:
                 description: |-
-                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is synced.
+                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
+                  successfully synced, and the last update is in a succeeded state.
                   The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
                 enum:
                 - Retain

--- a/deploy/crds/pulumi.com_stacks.yaml
+++ b/deploy/crds/pulumi.com_stacks.yaml
@@ -773,8 +773,7 @@ spec:
                 type: boolean
               workspaceReclaimPolicy:
                 description: |-
-                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
-                  successfully synced, and the last update is in a succeeded state.
+                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is successfully updated.
                   The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
                 enum:
                 - Retain
@@ -10410,8 +10409,7 @@ spec:
                 type: boolean
               workspaceReclaimPolicy:
                 description: |-
-                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
-                  successfully synced, and the last update is in a succeeded state.
+                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is successfully updated.
                   The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
                 enum:
                 - Retain

--- a/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
+++ b/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
@@ -773,7 +773,8 @@ spec:
                 type: boolean
               workspaceReclaimPolicy:
                 description: |-
-                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is synced.
+                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
+                  successfully synced, and the last update is in a succeeded state.
                   The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
                 enum:
                 - Retain
@@ -10409,7 +10410,8 @@ spec:
                 type: boolean
               workspaceReclaimPolicy:
                 description: |-
-                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is synced.
+                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
+                  successfully synced, and the last update is in a succeeded state.
                   The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
                 enum:
                 - Retain

--- a/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
+++ b/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
@@ -773,8 +773,7 @@ spec:
                 type: boolean
               workspaceReclaimPolicy:
                 description: |-
-                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
-                  successfully synced, and the last update is in a succeeded state.
+                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is successfully updated.
                   The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
                 enum:
                 - Retain
@@ -10410,8 +10409,7 @@ spec:
                 type: boolean
               workspaceReclaimPolicy:
                 description: |-
-                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
-                  successfully synced, and the last update is in a succeeded state.
+                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is successfully updated.
                   The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
                 enum:
                 - Retain

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -368,7 +368,8 @@ The default behavior is to create a stack if it doesn't exist.<br/>
         <td><b>workspaceReclaimPolicy</b></td>
         <td>enum</td>
         <td>
-          WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is synced.
+          WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
+successfully synced, and the last update is in a succeeded state.
 The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".<br/>
           <br/>
             <i>Enum</i>: Retain, Delete<br/>
@@ -19803,7 +19804,8 @@ The default behavior is to create a stack if it doesn't exist.<br/>
         <td><b>workspaceReclaimPolicy</b></td>
         <td>enum</td>
         <td>
-          WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is synced.
+          WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
+successfully synced, and the last update is in a succeeded state.
 The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".<br/>
           <br/>
             <i>Enum</i>: Retain, Delete<br/>

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -368,8 +368,7 @@ The default behavior is to create a stack if it doesn't exist.<br/>
         <td><b>workspaceReclaimPolicy</b></td>
         <td>enum</td>
         <td>
-          WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
-successfully synced, and the last update is in a succeeded state.
+          WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is successfully updated.
 The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".<br/>
           <br/>
             <i>Enum</i>: Retain, Delete<br/>
@@ -19804,8 +19803,7 @@ The default behavior is to create a stack if it doesn't exist.<br/>
         <td><b>workspaceReclaimPolicy</b></td>
         <td>enum</td>
         <td>
-          WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
-successfully synced, and the last update is in a succeeded state.
+          WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is successfully updated.
 The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".<br/>
           <br/>
             <i>Enum</i>: Retain, Delete<br/>

--- a/operator/api/pulumi/shared/stack_types.go
+++ b/operator/api/pulumi/shared/stack_types.go
@@ -155,8 +155,7 @@ type StackSpec struct {
 	// +optional
 	WorkspaceTemplate *WorkspaceApplyConfiguration `json:"workspaceTemplate,omitempty"`
 
-	// WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
-	// successfully synced, and the last update is in a succeeded state.
+	// WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is successfully updated.
 	// The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
 	// +optional
 	WorkspaceReclaimPolicy WorkspaceReclaimPolicy `json:"workspaceReclaimPolicy,omitempty"`

--- a/operator/api/pulumi/shared/stack_types.go
+++ b/operator/api/pulumi/shared/stack_types.go
@@ -155,7 +155,8 @@ type StackSpec struct {
 	// +optional
 	WorkspaceTemplate *WorkspaceApplyConfiguration `json:"workspaceTemplate,omitempty"`
 
-	// WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is synced.
+	// WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
+	// successfully synced, and the last update is in a succeeded state.
 	// The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
 	// +optional
 	WorkspaceReclaimPolicy WorkspaceReclaimPolicy `json:"workspaceReclaimPolicy,omitempty"`

--- a/operator/config/crd/bases/pulumi.com_stacks.yaml
+++ b/operator/config/crd/bases/pulumi.com_stacks.yaml
@@ -773,7 +773,8 @@ spec:
                 type: boolean
               workspaceReclaimPolicy:
                 description: |-
-                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is synced.
+                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
+                  successfully synced, and the last update is in a succeeded state.
                   The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
                 enum:
                 - Retain
@@ -10409,7 +10410,8 @@ spec:
                 type: boolean
               workspaceReclaimPolicy:
                 description: |-
-                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is synced.
+                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
+                  successfully synced, and the last update is in a succeeded state.
                   The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
                 enum:
                 - Retain

--- a/operator/config/crd/bases/pulumi.com_stacks.yaml
+++ b/operator/config/crd/bases/pulumi.com_stacks.yaml
@@ -773,8 +773,7 @@ spec:
                 type: boolean
               workspaceReclaimPolicy:
                 description: |-
-                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
-                  successfully synced, and the last update is in a succeeded state.
+                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is successfully updated.
                   The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
                 enum:
                 - Retain
@@ -10410,8 +10409,7 @@ spec:
                 type: boolean
               workspaceReclaimPolicy:
                 description: |-
-                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is
-                  successfully synced, and the last update is in a succeeded state.
+                  WorkspaceReclaimPolicy specifies whether the workspace should be deleted or retained after the Stack is successfully updated.
                   The default behavior is to retain the workspace. Valid values are one of "Retain" or "Delete".
                 enum:
                 - Retain

--- a/operator/internal/controller/pulumi/stack_controller_test.go
+++ b/operator/internal/controller/pulumi/stack_controller_test.go
@@ -951,21 +951,6 @@ var _ = Describe("Stack Controller", func() {
 							Expect(err).NotTo(HaveOccurred())
 							ByResyncing()
 						})
-
-						When("the WorkspaceReclaimPolicy is set to Delete", func() {
-							BeforeEach(func(ctx context.Context) {
-								obj.Spec.WorkspaceReclaimPolicy = shared.WorkspaceReclaimDelete
-							})
-							It("reconciles and delete the workspace pod", func(ctx context.Context) {
-								result, err := reconcileF(ctx)
-								Expect(err).NotTo(HaveOccurred())
-								ByMarkingAsReady()
-								By("not requeuing")
-								Expect(result).To(Equal(reconcile.Result{}))
-								By("deleting the Workspace object")
-								Expect(ws.GetName()).To(BeEmpty())
-							})
-						})
 					})
 				})
 

--- a/operator/internal/controller/pulumi/stack_controller_test.go
+++ b/operator/internal/controller/pulumi/stack_controller_test.go
@@ -794,10 +794,8 @@ var _ = Describe("Stack Controller", func() {
 						obj.Spec.WorkspaceReclaimPolicy = shared.WorkspaceReclaimDelete
 					})
 					It("does not delete the workspace pod", func(ctx context.Context) {
-						result, err := reconcileF(ctx)
+						_, err := reconcileF(ctx)
 						Expect(err).NotTo(HaveOccurred())
-						// 1 minute * 2^3
-						Expect(result.RequeueAfter).To(BeNumerically("~", 8*time.Minute, time.Minute))
 						By("not deleting the Workspace object")
 						Expect(ws.GetName()).NotTo(BeEmpty())
 					})

--- a/operator/internal/controller/pulumi/stack_controller_test.go
+++ b/operator/internal/controller/pulumi/stack_controller_test.go
@@ -788,6 +788,20 @@ var _ = Describe("Stack Controller", func() {
 					Expect(res.RequeueAfter).To(BeNumerically("~", 8*time.Minute, time.Minute))
 					ByMarkingAsReconciling(pulumiv1.ReconcilingRetryReason, Equal("3 update failure(s)"))
 				})
+
+				When("the WorkspaceReclaimPolicy is set to Delete", func() {
+					BeforeEach(func(ctx context.Context) {
+						obj.Spec.WorkspaceReclaimPolicy = shared.WorkspaceReclaimDelete
+					})
+					It("does not delete the workspace pod", func(ctx context.Context) {
+						result, err := reconcileF(ctx)
+						Expect(err).NotTo(HaveOccurred())
+						// 1 minute * 2^3
+						Expect(result.RequeueAfter).To(BeNumerically("~", 8*time.Minute, time.Minute))
+						By("not deleting the Workspace object")
+						Expect(ws.GetName()).NotTo(BeEmpty())
+					})
+				})
 			})
 			When("done cooling down", func() {
 				BeforeEach(func() {
@@ -938,6 +952,21 @@ var _ = Describe("Stack Controller", func() {
 							_, err := reconcileF(ctx)
 							Expect(err).NotTo(HaveOccurred())
 							ByResyncing()
+						})
+
+						When("the WorkspaceReclaimPolicy is set to Delete", func() {
+							BeforeEach(func(ctx context.Context) {
+								obj.Spec.WorkspaceReclaimPolicy = shared.WorkspaceReclaimDelete
+							})
+							It("reconciles and delete the workspace pod", func(ctx context.Context) {
+								result, err := reconcileF(ctx)
+								Expect(err).NotTo(HaveOccurred())
+								ByMarkingAsReady()
+								By("not requeuing")
+								Expect(result).To(Equal(reconcile.Result{}))
+								By("deleting the Workspace object")
+								Expect(ws.GetName()).To(BeEmpty())
+							})
 						})
 					})
 				})


### PR DESCRIPTION
### Proposed changes

This PR fixes it so that the Workspace pod is not reclaimed when the update failed. We should only delete the pod if the sync was successful, and the update was also successful.

### Related issues (optional)

Closes: #826
