### PR TITLE
Sync built images to ECR and GHCR on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,9 +35,15 @@ jobs:
             pulumi/pulumi-kubernetes-operator:${{ env.VERSION }}
           build-args: |
             VERSION=${{ env.VERSION }}
+  sync-images:
+    uses: ./.github/workflows/sync-images.yaml
+    needs: docker
+    secrets: inherit
+    with:
+      operator_version: ${{ env.VERSION }}
   release:
     name: Create a GitHub Release
-    needs: docker
+    needs: [docker, sync-images]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/sync-ecr.yaml
+++ b/.github/workflows/sync-ecr.yaml
@@ -46,7 +46,7 @@ jobs:
             docker login -u AWS --password-stdin https://public.ecr.aws
       - name: Copy ${{ env.OPERATOR_VERSION }} image to AWS Public ECR
         run: |
-          skopeo copy docker://docker.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }} docker://public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}
+          skopeo copy --all docker://docker.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }} docker://public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}
       - name: Copy ${{ env.OPERATOR_VERSION }} image to GitHub Container Registry
         run: |
-          skopeo copy docker://docker.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }} docker://ghcr.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}
+          skopeo copy --all docker://docker.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }} docker://ghcr.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}

--- a/.github/workflows/sync-ecr.yaml
+++ b/.github/workflows/sync-ecr.yaml
@@ -44,14 +44,9 @@ jobs:
             --query 'authorizationData.authorizationToken' | \
             tr -d '"' | base64 --decode | cut -d: -f2 | \
             docker login -u AWS --password-stdin https://public.ecr.aws
-      - name: Pull ${{ env.OPERATOR_VERSION }} from Docker Hub
+      - name: Copy ${{ env.OPERATOR_VERSION }} image to AWS Public ECR
         run: |
-          docker pull docker.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}
-      - name: Tag ${{ env.OPERATOR_VERSION }} and push to AWS Public ECR
+          skopeo copy docker://docker.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }} docker://public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}
+      - name: Copy ${{ env.OPERATOR_VERSION }} image to GitHub Container Registry
         run: |
-          docker tag docker.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }} public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}
-          docker push public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}
-      - name: Tag ${{ env.OPERATOR_VERSION }} and push to GitHub Container Registry
-        run: |
-          docker tag docker.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }} ghcr.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}
-          docker push ghcr.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}
+          skopeo copy docker://docker.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }} docker://ghcr.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}

--- a/.github/workflows/sync-images.yaml
+++ b/.github/workflows/sync-images.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       operator_version:
-        description: The image tag to copy, fully specified, e.g. "3.18.1"
+        description: The image tag to copy, fully specified, e.g. "v2.0.0"
         type: string
         required: true
   repository_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
 - Use audience-scoped access token. [#816](https://github.com/pulumi/pulumi-kubernetes-operator/pull/816)
 - Enable setting the log verbosity of Pulumi CLI operations for a given workspace. [#824](https://github.com/pulumi/pulumi-kubernetes-operator/pull/824)
 - Use pulumi.com labels [#829](https://github.com/pulumi/pulumi-kubernetes-operator/pull/829)
+- Releases will now be published to AWS ECR and GHCR [#831](https://github.com/pulumi/pulumi-kubernetes-operator/pull/831)
 
 ## 2.0.0-beta.3 (2024-11-27)
 


### PR DESCRIPTION
### Proposed changes
This PR extends #830 by enabling image synchronization during the release job. The syncing process is now more reliable, as it has been updated to use [skopeo](https://github.com/containers/skopeo) for copying. Leveraging `skopeo` brings the added advantage of supporting image copying across all architecture types, rather than being limited to the host machine's architecture.

An example passing run: https://github.com/pulumi/pulumi-kubernetes-operator/actions/runs/13339040901

### Related issues (optional)

Closes: #811
Closes: #481 