### PR TITLE
feat: add GHA summary for image sync job

### DIFF
--- a/.github/workflows/sync-images.yaml
+++ b/.github/workflows/sync-images.yaml
@@ -52,5 +52,5 @@ jobs:
           skopeo copy --all docker://docker.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }} docker://ghcr.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}
       - name: Output build summary
         run: |
-          SUMMARY=$'# Image Syncing Summary\nSource Image: pulumi/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}\n\nDestination Images:\n- public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}\n- ghcr.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}'
+          SUMMARY=$'# Image Syncing Summary\nSource Image: `pulumi/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}`\n\nDestination Images:\n- `public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}`\n- `ghcr.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}`'
           echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sync-images.yaml
+++ b/.github/workflows/sync-images.yaml
@@ -50,3 +50,7 @@ jobs:
       - name: Copy ${{ env.OPERATOR_VERSION }} image to GitHub Container Registry
         run: |
           skopeo copy --all docker://docker.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }} docker://ghcr.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}
+      - name: Output build summary
+        run: |
+          SUMMARY=$'# Image Syncing Summary\nSource Image: pulumi/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}\n\nDestination Images:\n- public.ecr.aws/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}\n- ghcr.io/${{ env.DOCKER_USERNAME }}/${{ env.OPERATOR_IMAGE_NAME }}:${{ env.OPERATOR_VERSION }}'
+          echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

Adds GHA summary to summarize what images were copied to/from.
https://github.com/pulumi/pulumi-kubernetes-operator/actions/runs/13340031451 is a live example of this.

### Screenshot
![Screenshot from 2025-02-14 16-47-21](https://github.com/user-attachments/assets/4b601dc0-161d-42b9-bb65-1686473f1b4d)

### Related Issues (optional)
Closes: #833 

