### PR TITLE
Sample network policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## Unreleased
+
+- Sample network policies [#839](https://github.com/pulumi/pulumi-kubernetes-operator/pull/839)
+
 ## 2.0.0-rc.1 (2025-02-15)
 
 - Reduce volatility of the workspace due to ordering and caching issues [#803](https://github.com/pulumi/pulumi-kubernetes-operator/pull/803)

--- a/operator/config/flux/network_policy.yaml
+++ b/operator/config/flux/network_policy.yaml
@@ -17,10 +17,8 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: default
-        - podSelector:
+          podSelector:
             matchLabels:
-              app.kubernetes.io/managed-by: pulumi-kubernetes-operator
-              app.kubernetes.io/name: pulumi
-              app.kubernetes.io/component: workspace
+              auto.pulumi.com/component: workspace
   policyTypes:
     - Ingress

--- a/operator/config/quickstart/kustomization.yaml
+++ b/operator/config/quickstart/kustomization.yaml
@@ -2,3 +2,4 @@ resources:
   - ../default
   - service_account.yaml
   - rbac.yaml
+  - network_policy.yaml

--- a/operator/config/quickstart/network_policy.yaml
+++ b/operator/config/quickstart/network_policy.yaml
@@ -1,0 +1,24 @@
+# A network policy to allow Pulumi workspaces in the `default` namespace to
+# accept RPC traffic from the controller-manager in the `pulumi-kubernetes-operator` namespace.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-workspace-rpc
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      auto.pulumi.com/component: workspace
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: grpc
+      from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: pulumi-kubernetes-operator
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: pulumi-kubernetes-operator
+  policyTypes:
+    - Ingress


### PR DESCRIPTION

### Proposed changes

This PR adds a sample network policy to the quickstart manifest, and fixes the labels used in sample Flux network policy.

In Kubernetes clusters that have Network Policy enabled, a policy may be needed for two types of traffic:
1. operator-to-workspace (for RPC traffic)
2. workspace-to-flux-source-controller (for artifact fetching)