### PR TITLE
feat: reduce docker image size by 30%

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,target=${GOCACHE} \
     --mount=type=bind,source=/agent,target=./agent \
     --mount=type=bind,source=/operator,target=./operator \
     CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
-    go build -a -o /manager -ldflags="-X github.com/pulumi/pulumi-kubernetes-operator/v2/operator/version.Version=${VERSION}" ./operator/cmd/main.go
+    go build -a -o /manager -ldflags="-s -w -X github.com/pulumi/pulumi-kubernetes-operator/v2/operator/version.Version=${VERSION}" ./operator/cmd/main.go
 
 # Build the agent.
 FROM --platform=${BUILDPLATFORM} base AS agent-builder
@@ -37,7 +37,7 @@ RUN --mount=type=cache,target=${GOCACHE} \
     --mount=type=cache,target=${GOMODCACHE} \
     --mount=type=bind,source=/agent,target=./agent \
     CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} \
-    go build -a -o /agent -ldflags "-X github.com/pulumi/pulumi-kubernetes-operator/v2/agent/version.Version=${VERSION}" ./agent/main.go
+    go build -a -o /agent -ldflags "-s -w -X github.com/pulumi/pulumi-kubernetes-operator/v2/agent/version.Version=${VERSION}" ./agent/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION


<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

apply common best practice for production builds to reduce weight of produced binaries. This decrease the size significantly from 171MB to 119MB.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
