### PR TITLE
fix: indentation in cluster role with extra rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## Unreleased
 
+- Fixed `rbac.extraRules` in Helm chart [#875](https://github.com/pulumi/pulumi-kubernetes-operator/pull/875)
 - New example: pulumi-ts [#843](https://github.com/pulumi/pulumi-kubernetes-operator/pull/843)
 
 ## 2.0.0 (2025-02-18)

--- a/deploy/helm/pulumi-operator/templates/clusterrole.yaml
+++ b/deploy/helm/pulumi-operator/templates/clusterrole.yaml
@@ -9,191 +9,191 @@ rules:
   {{- if .Values.rbac.extraRules }}
     {{- toYaml .Values.rbac.extraRules | nindent 2 }}
   {{- end }}
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - auto.pulumi.com
-  resources:
-  - updates
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - auto.pulumi.com
-  resources:
-  - updates/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - auto.pulumi.com
-  resources:
-  - updates/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - auto.pulumi.com
-  resources:
-  - workspaces
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - auto.pulumi.com
-  resources:
-  - workspaces/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - auto.pulumi.com
-  resources:
-  - workspaces/rpc
-  verbs:
-  - use
-- apiGroups:
-  - auto.pulumi.com
-  resources:
-  - workspaces/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - pulumi.com
-  resources:
-  - programs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - pulumi.com
-  resources:
-  - programs/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - pulumi.com
-  resources:
-  - programs/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - pulumi.com
-  resources:
-  - stacks
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - pulumi.com
-  resources:
-  - stacks/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - pulumi.com
-  resources:
-  - stacks/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - source.toolkit.fluxcd.io
-  resources:
-  - buckets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - source.toolkit.fluxcd.io
-  resources:
-  - gitrepositories
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - source.toolkit.fluxcd.io
-  resources:
-  - ocirepositories
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - statefulsets
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - auto.pulumi.com
+    resources:
+    - updates
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - auto.pulumi.com
+    resources:
+    - updates/finalizers
+    verbs:
+    - update
+  - apiGroups:
+    - auto.pulumi.com
+    resources:
+    - updates/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - auto.pulumi.com
+    resources:
+    - workspaces
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - auto.pulumi.com
+    resources:
+    - workspaces/finalizers
+    verbs:
+    - update
+  - apiGroups:
+    - auto.pulumi.com
+    resources:
+    - workspaces/rpc
+    verbs:
+    - use
+  - apiGroups:
+    - auto.pulumi.com
+    resources:
+    - workspaces/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - pulumi.com
+    resources:
+    - programs
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - pulumi.com
+    resources:
+    - programs/finalizers
+    verbs:
+    - update
+  - apiGroups:
+    - pulumi.com
+    resources:
+    - programs/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - pulumi.com
+    resources:
+    - stacks
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - pulumi.com
+    resources:
+    - stacks/finalizers
+    verbs:
+    - update
+  - apiGroups:
+    - pulumi.com
+    resources:
+    - stacks/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - source.toolkit.fluxcd.io
+    resources:
+    - buckets
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - source.toolkit.fluxcd.io
+    resources:
+    - gitrepositories
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - source.toolkit.fluxcd.io
+    resources:
+    - ocirepositories
+    verbs:
+    - get
+    - list
+    - watch
 {{- end }}


### PR DESCRIPTION
### Proposed changes

When setting `rbac.extraRules`  in the Helm chart, rendered template has the wrong indentation. This fixes the indentation.