### PR TITLE
Fix for weekly-pulumi-update failures

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,8 @@
 [tools]
 golangci-lint = "1.58.1"
 etcd = "3.5.16"
-protoc-gen-go = "1.34.2"
+protoc = "29.3"
+protoc-gen-go = "1.36.4"
 protoc-gen-go-grpc = "1.5.1"
 kubebuilder = "4.2.0"
 envsubst = "1.4.2"

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -1,6 +1,6 @@
 VERSION ?= $(shell git describe --tags --always --dirty)
 
-all: protoc agent
+all: agent
 
 protoc:
 	cd pkg/proto && protoc --go_out=. --go_opt=paths=source_relative \
@@ -9,7 +9,7 @@ protoc:
 test:
 	go test -covermode=atomic -coverprofile=coverage.out -coverpkg=./... -v ./...
 	
-agent: protoc
+agent:
 	go build -o pulumi-kubernetes-agent \
 		-ldflags "-X github.com/pulumi/pulumi-kubernetes-operator/v2/agent/version.Version=${VERSION}" \
 		main.go


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

The proposed fix is to not run `protoc` in `make build`, meaning that one must manually run `make protoc` whenever one makes a change to the .proto files. We commit the generated code anyway. This is consistent with how pulumi/pulumi is built (see [proto/generate.sh](https://github.com/pulumi/pulumi/blob/627d1554626f4a28426e15d8dd77f6f2c53d02dc/proto/generate.sh#L5-L7)).

Since we're relying on manual runs of protoc, the mise configuration was also updated and tested. 

Once this PR closes, we'll re-run the weekly-pulumi-update workflow.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #849