### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -1,4 +1,11 @@
 ---
+permissions: write-all # Equivalent to default permissions plus id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: Command Dispatch for testing
 on:
   issue_comment:
@@ -8,11 +15,14 @@ jobs:
   command-dispatch-for-testing:
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@v2
       - name: Run Build
         uses: peter-evans/slash-command-dispatch@v2
         with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           commands: run-acceptance-tests
           permission: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,25 +3,33 @@ name: Pulumi Kubernetes Operator Release
 on:
   push:
     tags:
-      - v*.*.*     # e.g. v2.0.0
-      - v*.*-*.*   # e.g. v2.0-beta.0
-      - v*.*.*-*.*   # e.g. v2.0.0-beta.1
+      - v*.*.* # e.g. v2.0.0
+      - v*.*-*.* # e.g. v2.0-beta.0
+      - v*.*.*-*.* # e.g. v2.0.0-beta.1
 env:
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   VERSION: ${{ github.ref_name }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: PULUMI_ACCESS_TOKEN
 permissions:
   contents: write
+  id-token: write
 jobs:
   docker:
     name: Build & Push Docker Images
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ steps.esc-secrets.outputs.DOCKER_USERNAME }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_PASSWORD }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -46,6 +54,9 @@ jobs:
     needs: [docker]
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout
         uses: actions/checkout@v4
       - name: Create a GH release

--- a/.github/workflows/run-acceptance-tests.yaml
+++ b/.github/workflows/run-acceptance-tests.yaml
@@ -1,4 +1,5 @@
 ---
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: Pulumi Kubernetes Operator PR Builds
 on:
   push:
@@ -8,15 +9,21 @@ on:
     branches:
       - master
 env:
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  PULUMI_BOT_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   VERSION: v0.0-${{ github.sha }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: PULUMI_ACCESS_TOKEN,PULUMI_BOT_TOKEN
 jobs:
   build:
     runs-on: ubuntu-latest
     name: Build
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Check out code
         uses: actions/checkout@v4
         with:
@@ -28,8 +35,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ steps.esc-secrets.outputs.DOCKER_USERNAME }}
+          password: ${{ steps.esc-secrets.outputs.DOCKER_PASSWORD }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build
@@ -42,11 +49,15 @@ jobs:
             pulumi/pulumi-kubernetes-operator:${{ env.VERSION }}
           build-args: |
             VERSION=${{ env.VERSION }}
-  
+
+
   lint:
     runs-on: ubuntu-latest
     name: Lint
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Check out code
         uses: actions/checkout@v4
         with:
@@ -62,6 +73,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Unit tests
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Check out code
         uses: actions/checkout@v4
         with:
@@ -83,12 +97,15 @@ jobs:
         with:
           files: agent/coverage.out,operator/coverage.out
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
 
   e2e-tests:
     runs-on: ubuntu-latest
     name: E2E tests
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Setup cluster
         uses: helm/kind-action@v1
         with:
@@ -108,4 +125,4 @@ jobs:
         uses: stateful/vscode-server-action@v1
         if: failure()
         with:
-          timeout: '360000'       # milliseconds
+          timeout: '360000' # milliseconds

--- a/.github/workflows/sync-images.yaml
+++ b/.github/workflows/sync-images.yaml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 # Copies all Pulumi Kubernetes Operator OCI images for the supplied version from Docker Hub to
 # AWS ECR Public Gallery and GitHub Container Registry.
 name: Sync Docker Hub Images to ECR and GHCR
@@ -22,12 +23,20 @@ env:
   DOCKER_USERNAME: pulumi
   OPERATOR_VERSION: ${{ inputs.operator_version || github.event.client_payload.ref }}
   OPERATOR_IMAGE_NAME: pulumi-kubernetes-operator
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 
 jobs:
   sync-to-ecr:
     name: Pulumi Kubernetes Operator image
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:
@@ -37,7 +46,7 @@ jobs:
           role-duration-seconds: 3600
           role-external-id: upload-pulumi-release
           role-session-name: pulumi@githubActions
-          role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
+          role-to-assume: ${{ steps.esc-secrets.outputs.AWS_UPLOAD_ROLE_ARN }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
         with:

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: weekly-pulumi-update
 "on":
   schedule:
@@ -5,7 +6,11 @@ name: weekly-pulumi-update
   workflow_dispatch: {}
 
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN
 
 jobs:
   update-go-mod:
@@ -15,6 +20,9 @@ jobs:
       matrix:
         goversion: [1.23.x]
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout Repo
         uses: actions/checkout@v2
       - name: Unshallow clone for tags
@@ -63,4 +71,4 @@ jobs:
           pr_title: "Automated pulumi/pulumi upgrade"
           pr_label: "automation/merge"
           pr_allow_empty: true
-          github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
