### PR TITLE
run acceptance tests on repository_dispatch

### DIFF
--- a/.github/workflows/run-acceptance-tests.yaml
+++ b/.github/workflows/run-acceptance-tests.yaml
@@ -1,6 +1,8 @@
 ---
 name: Pulumi Kubernetes Operator PR Builds
 on:
+  repository_dispatch:
+    types: [run-acceptance-tests-command]
   push:
     branches:
       - master
@@ -13,6 +15,23 @@ env:
   PULUMI_BOT_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   VERSION: v0.0-${{ github.sha }}
 jobs:
+  comment-notification:
+    runs-on: ubuntu-latest
+    name: comment-notification
+    if: github.event_name == 'repository_dispatch'
+    steps:
+    - name: Create URL to the run output
+      id: vars
+      run: echo
+        run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+        >> "$GITHUB_OUTPUT"
+    - name: Update with Result
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+      with:
+        token: ${{ secrets.PULUMI_BOT_TOKEN }}
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+        body: "Please view the PR build: ${{ steps.vars.outputs.run-url }}"
   build:
     runs-on: ubuntu-latest
     name: Build
@@ -88,6 +107,8 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     name: E2E tests
+    if: github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Setup cluster
         uses: helm/kind-action@v1


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Enables the handling of the "run acceptance tests" command, a part of the chatops way to allow for forked PR to run safely.

Here's where the process stalled: https://github.com/pulumi/pulumi-kubernetes-operator/actions/runs/15122091096/job/42506595319

in PKO v1: https://github.com/pulumi/pulumi-kubernetes-operator/blob/v1.16.0/.github/workflows/run-acceptance-tests.yaml

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
