### PR TITLE
refactor: run-acceptance-tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,44 @@
+---
+name: Build
+on:
+  workflow_call:
+    inputs:
+      repository:
+        required: true
+        type: string
+      ref:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.x
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: |
+            pulumi/pulumi-kubernetes-operator:${{ inputs.version }}
+          build-args: |
+            VERSION=${{ inputs.version }}

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,0 +1,28 @@
+---
+name: E2E Tests
+on:
+  workflow_call:
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: kind
+          node_image: kindest/node:v1.31.0
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.x
+      - name: Run tests
+        run: make -C operator test-e2e
+      - name: 🐛 Debug Build
+        uses: stateful/vscode-server-action@v1
+        if: failure()
+        with:
+          timeout: '360000'

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -2,6 +2,13 @@
 name: E2E Tests
 on:
   workflow_call:
+    inputs:
+      repository:
+        required: true
+        type: string
+      ref:
+        required: true
+        type: string
 jobs:
   e2e-tests:
     runs-on: ubuntu-latest
@@ -14,6 +21,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,6 +2,13 @@
 name: Lint
 on:
   workflow_call:
+    inputs:
+      repository:
+        required: true
+        type: string
+      ref:
+        required: true
+        type: string
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -9,6 +16,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v5

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,18 @@
+---
+name: Lint
+on:
+  workflow_call:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.x
+      - name: Lint pulumi-kubernetes-operator codebase
+        run: make lint

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -21,11 +21,20 @@ jobs:
   lint:
     uses: ./.github/workflows/lint.yaml
     secrets: inherit
+    with:
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref_name }}
 
   unit-tests:
     uses: ./.github/workflows/unit-tests.yaml
     secrets: inherit
+    with:
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref_name }}
 
   e2e-tests:
     uses: ./.github/workflows/e2e-tests.yaml
     secrets: inherit
+    with:
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref_name }}

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -1,0 +1,31 @@
+---
+name: Pulumi Kubernetes Operator Master Build
+on:
+  push:
+    branches:
+      - master
+env:
+  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PULUMI_BOT_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  VERSION: v0.0-${{ github.sha }}
+jobs:
+  build:
+    uses: ./.github/workflows/build.yaml
+    secrets: inherit
+    with:
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref_name }}
+      version: v0.0-${{ github.sha }}
+
+  lint:
+    uses: ./.github/workflows/lint.yaml
+    secrets: inherit
+
+  unit-tests:
+    uses: ./.github/workflows/unit-tests.yaml
+    secrets: inherit
+
+  e2e-tests:
+    uses: ./.github/workflows/e2e-tests.yaml
+    secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@main
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: |
             PR is now waiting for a maintainer to run the acceptance tests. This PR will only perform build and linting.
             **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-acceptance-tests.yaml
+++ b/.github/workflows/run-acceptance-tests.yaml
@@ -1,14 +1,11 @@
 ---
 name: Pulumi Kubernetes Operator PR Builds
 on:
-  repository_dispatch:
-    types: [run-acceptance-tests-command]
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
+  repository_dispatch:
+    types: [run-acceptance-tests-command]
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,105 +29,29 @@ jobs:
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
         body: "Please view the PR build: ${{ steps.vars.outputs.run-url }}"
+
   build:
-    runs-on: ubuntu-latest
-    name: Build
+    uses: ./.github/workflows/build.yaml
+    secrets: inherit
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.23.x
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build
-        uses: docker/build-push-action@v6
-        with:
-          push: false
-          load: true
-          platforms: linux/amd64
-          tags: |
-            pulumi/pulumi-kubernetes-operator:${{ env.VERSION }}
-          build-args: |
-            VERSION=${{ env.VERSION }}
-  
+    with:
+      repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+      ref: ${{ github.event.client_payload.pull_request.head.ref }}
+      version: v0.0-${{ github.sha }}
+
   lint:
-    runs-on: ubuntu-latest
-    name: Lint
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.23.x
-      - name: Lint pulumi-kubernetes-operator codebase
-        run: make lint
+    uses: ./.github/workflows/lint.yaml
+    secrets: inherit
 
   unit-tests:
-    runs-on: ubuntu-latest
-    name: Unit tests
+    uses: ./.github/workflows/unit-tests.yaml
+    secrets: inherit
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.23.x
-      - name: Install Pulumi CLI
-        uses: pulumi/actions@df5a93ad715135263c732ba288301bd044c383c0 # v6.3.0
-        with:
-          pulumi-version-file: .pulumi.version
-      - name: Run Tests (Agent)
-        run: make -C agent test
-      - name: Run Tests (Operator)
-        run: make -C operator test
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: agent/coverage.out,operator/coverage.out
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
+      
   e2e-tests:
-    runs-on: ubuntu-latest
-    name: E2E tests
+    uses: ./.github/workflows/e2e-tests.yaml
+    secrets: inherit
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    steps:
-      - name: Setup cluster
-        uses: helm/kind-action@v1
-        with:
-          cluster_name: kind
-          node_image: kindest/node:v1.31.0
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.23.x
-      - name: Run tests
-        run: make -C operator test-e2e
-      - name: 🐛 Debug Build
-        uses: stateful/vscode-server-action@v1
-        if: failure()
-        with:
-          timeout: '360000'       # milliseconds

--- a/.github/workflows/run-acceptance-tests.yaml
+++ b/.github/workflows/run-acceptance-tests.yaml
@@ -43,15 +43,24 @@ jobs:
   lint:
     uses: ./.github/workflows/lint.yaml
     secrets: inherit
+    with:
+      repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+      ref: ${{ github.event.client_payload.pull_request.head.ref }}
 
   unit-tests:
     uses: ./.github/workflows/unit-tests.yaml
     secrets: inherit
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-      
+    with:
+      repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+      ref: ${{ github.event.client_payload.pull_request.head.ref }}
+
   e2e-tests:
     uses: ./.github/workflows/e2e-tests.yaml
     secrets: inherit
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    with:
+      repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+      ref: ${{ github.event.client_payload.pull_request.head.ref }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,30 @@
+---
+name: Unit Tests
+on:
+  workflow_call:
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.23.x
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v6
+        with:
+          pulumi-version-file: .pulumi.version
+      - name: Run Tests (Agent)
+        run: make -C agent test
+      - name: Run Tests (Operator)
+        run: make -C operator test
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: agent/coverage.out,operator/coverage.out
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -2,6 +2,13 @@
 name: Unit Tests
 on:
   workflow_call:
+    inputs:
+      repository:
+        required: true
+        type: string
+      ref:
+        required: true
+        type: string
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
@@ -9,6 +16,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
       - name: Install Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Dealing with a problem of how to correctly clone a forked PR branch. Following closely the pattern in ci-mgmt.

Refactors the run-acceptance-tests.yaml workflow into its parts, to be reusable by a new workflow (master.yaml) that would run on the `push:` event.  Run the acceptance tests on `pull_request` and `repository_action`.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
