### PR TITLE
Deprecate ResourceSelectorType "FS" and "Env"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 - Fixed `rbac.extraRules` in Helm chart [#875](https://github.com/pulumi/pulumi-kubernetes-operator/pull/875)
 - New example: pulumi-ts [#843](https://github.com/pulumi/pulumi-kubernetes-operator/pull/843)
 - Use optimized binaries in container images [#852](https://github.com/pulumi/pulumi-kubernetes-operator/pull/852)
+- Deprecate ResourceSelectorType "FS" and "Env" [#920](https://github.com/pulumi/pulumi-kubernetes-operator/pull/920)
 
 ## 2.0.0 (2025-02-18)
 

--- a/operator/api/pulumi/shared/stack_types.go
+++ b/operator/api/pulumi/shared/stack_types.go
@@ -334,9 +334,9 @@ func NewLiteralResourceRef(value string) ResourceRef {
 type ResourceSelectorType string
 
 const (
-	// ResourceSelectorEnv indicates the resource is an environment variable
+	// Deprecated: ResourceSelectorEnv indicates the resource is an environment variable
 	ResourceSelectorEnv = ResourceSelectorType("Env")
-	// ResourceSelectorFS indicates the resource is on the filesystem
+	// Deprecated: ResourceSelectorFS indicates the resource is on the filesystem
 	ResourceSelectorFS = ResourceSelectorType("FS")
 	// ResourceSelectorSecret indicates the resource is a Kubernetes Secret
 	ResourceSelectorSecret = ResourceSelectorType("Secret")

--- a/operator/api/pulumi/shared/stack_types.go
+++ b/operator/api/pulumi/shared/stack_types.go
@@ -334,9 +334,9 @@ func NewLiteralResourceRef(value string) ResourceRef {
 type ResourceSelectorType string
 
 const (
-	// Deprecated: ResourceSelectorEnv indicates the resource is an environment variable
+	// ResourceSelectorEnv indicates the resource is an environment variable
 	ResourceSelectorEnv = ResourceSelectorType("Env")
-	// Deprecated: ResourceSelectorFS indicates the resource is on the filesystem
+	// ResourceSelectorFS indicates the resource is on the filesystem
 	ResourceSelectorFS = ResourceSelectorType("FS")
 	// ResourceSelectorSecret indicates the resource is a Kubernetes Secret
 	ResourceSelectorSecret = ResourceSelectorType("Secret")

--- a/operator/api/pulumi/v1/stack_types.go
+++ b/operator/api/pulumi/v1/stack_types.go
@@ -82,8 +82,6 @@ const (
 	StalledSourceUnavailableReason = "SourceUnavailable"
 	// Stalled because there was a conflict with another update, and retryOnConflict was not set.
 	StalledConflictReason = "UpdateConflict"
-	// Stalled because a cross-namespace ref is used, and namespace isolation is in effect.
-	StalledCrossNamespaceRefForbiddenReason = "CrossNamespaceRefForbidden"
 
 	// Ready because processing has completed
 	ReadyCompletedReason = "ProcessingCompleted"


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

This PR makes a breaking API change for security reasons, it removes support for "FS" and "Env"-type resource selectors in the `Stack` spec. They allow a Stack to draw environment variable values and files out of the operator's own pod. This could be used to elevate a user's privileges by obtaining the operator's own local files, such as its service account token. in`/var/secrets/...`.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #876 