### PR TITLE
More cloud logging options

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,25 +9,9 @@
 			"type": "go",
 			"request": "launch",
 			"mode": "auto",
-			"program": "cmd/manager",
-			"env": {
-				"WATCH_NAMESPACE": "default",
-				// "INSECURE_NO_NAMESPACE_ISOLATION": "true",
-				"OPERATOR_NAME": "pulumi-kubernetes-operator",
-			},
-			"args": [
-				"--zap-level=debug"
-			]
-		},
-		{
-			"name": "Manager (v2)",
-			"type": "go",
-			"request": "launch",
-			"mode": "auto",
 			"program": "operator/cmd",
 			"args": [
-				"--zap-encoder=console",
-				"--zap-log-level=debug"
+				"--zap-devel",
 			],
 			"env": {
 				"WORKSPACE_LOCALHOST": "localhost:50051",
@@ -35,7 +19,7 @@
 			},
 		},
 		{
-			"name": "Agent (v2)",
+			"name": "Agent",
 			"type": "go",
 			"request": "launch",
 			"mode": "auto",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 - Support for ESC environments in the Stack resource [#924](https://github.com/pulumi/pulumi-kubernetes-operator/pull/924)
 - Add an updateTemplate to the Stack spec [#925](https://github.com/pulumi/pulumi-kubernetes-operator/pull/925)
 - Update to Go 1.24 [#926](https://github.com/pulumi/pulumi-kubernetes-operator/pull/926)
+- More cloud logging options [#927](https://github.com/pulumi/pulumi-kubernetes-operator/pull/927)
 
 ## 2.0.0 (2025-02-18)
 

--- a/deploy/helm/pulumi-operator/templates/deployment.yaml
+++ b/deploy/helm/pulumi-operator/templates/deployment.yaml
@@ -40,6 +40,7 @@ spec:
         - --metrics-bind-address=:8383
         - --program-fs-adv-addr={{ include "pulumi-kubernetes-operator.advertisedAddress" . }}:80
         - --zap-log-level={{ .Values.controller.logLevel }}
+        - --zap-encoder={{ .Values.controller.logFormat }}
         - --zap-time-encoding=iso8601
         env:
         {{- if .Values.extraEnv }}

--- a/deploy/helm/pulumi-operator/values.yaml
+++ b/deploy/helm/pulumi-operator/values.yaml
@@ -23,6 +23,8 @@ imagePullSecrets: ""
 controller:
   # -- Log Level ('debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity)
   logLevel: info
+  # -- Log format (one of 'json' or 'console')
+  logFormat: console
   # -- the advertised address for the controller's service
   # advertisedAddress: "pulumi-kubernetes-operator.pulumi-kubernetes-operator.svc.cluster.local"
 

--- a/deploy/quickstart/install.yaml
+++ b/deploy/quickstart/install.yaml
@@ -29196,6 +29196,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --program-fs-adv-addr=pulumi-kubernetes-operator.$(POD_NAMESPACE):80
         - --zap-log-level=info
+        - --zap-encoder=console
         - --zap-time-encoding=iso8601
         env:
         - name: POD_NAMESPACE

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -33,9 +33,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -90,13 +92,17 @@ func main() {
 		"The address the static file server binds to.")
 	flag.StringVar(&programFSAdvAddr, "program-fs-adv-addr", envOrDefault("PROGRAM_FS_ADV_ADDR", ""),
 		"The advertised address of the static file server.")
+
+	// Configure Zap-based logging for klog/v2 and for the controller manager.
+	// Write to stdout by default.
 	opts := zap.Options{
-		Development: true,
+		DestWriter: os.Stdout,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
-
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	logger := zap.New(zap.UseFlagOptions(&opts))
+	klog.SetLogger(logger)
+	ctrllog.SetLogger(logger)
 
 	setupLog.Info("Pulumi Kubernetes Operator Manager",
 		"version", version.Version,

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -49,6 +49,7 @@ spec:
             - --health-probe-bind-address=:8081
             - --program-fs-adv-addr=pulumi-kubernetes-operator.$(POD_NAMESPACE):80
             - --zap-log-level=info
+            - --zap-encoder=console
             - --zap-time-encoding=iso8601
           ports:
           - containerPort: 8383


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This PR tweaks the operator's logging code to write to stdout rather than to stderr, and to support structured json output.

See ["Best practices"](https://cloud.google.com/kubernetes-engine/docs/concepts/about-logs#best_practices):
> Severities: By default, logs written to the standard output are on the INFO level and logs written to the standard error are on the ERROR level. Structured logs can include a severity field, which defines the log's severity.

The Helm chart now supports the following logging options:

```yaml
controller:
  # -- Log Level ('debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity)
  logLevel: info
  # -- Log format (one of 'json' or 'console')
  logFormat: console
```

When running the operator in your IDE, the "development mode" is enabled (i.e. debug-level, console format).

### Examples

#### Console Format

```
2025-05-23T20:11:09.067Z INFO    setup   Pulumi Kubernetes Operator Manager      {"version": "v2.0.0"}
2025-05-23T20:11:09.155Z INFO    setup   starting file server for program resource       {"address": ":9090", "advertisedAddress": "pulumi-kubernetes-operator.pulumi-kubernetes-operator:80"}
2025-05-23T20:11:09.155Z INFO    setup   starting manager
2025-05-23T20:11:09.156Z INFO    controller-runtime.metrics      Starting metrics server
2025-05-23T20:11:09.156Z INFO    setup   disabling http/2
2025-05-23T20:11:09.156Z INFO    starting server {"name": "health probe", "addr": "[::]:8081"}
2025-05-23T20:11:09.257Z INFO    attempting to acquire leader lease pulumi-kubernetes-operator/operator.pulumi.com...
2025-05-23T20:11:11.353Z INFO    controller-runtime.metrics      Serving metrics server  {"bindAddress": ":8383", "secure"
```

#### JSON Format

```jsonl
{"level":"info","ts":"2025-05-23T20:08:41.331Z","logger":"setup","msg":"Pulumi Kubernetes Operator Manager","version":"v2.0.0"}
{"level":"info","ts":"2025-05-23T20:08:41.408Z","logger":"setup","msg":"starting file server for program resource","address":":9090","advertisedAddress":"pulumi-kubernetes-operator.pulumi-kubernetes-operator:80"}
{"level":"info","ts":"2025-05-23T20:08:41.408Z","logger":"setup","msg":"starting manager"}
{"level":"info","ts":"2025-05-23T20:08:41.408Z","logger":"controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2025-05-23T20:08:41.408Z","logger":"setup","msg":"disabling http/2"}
{"level":"info","ts":"2025-05-23T20:08:41.409Z","msg":"starting server","name":"health probe","addr":"[::]:8081"}
{"level":"info","ts":"2025-05-23T20:08:41.512Z","msg":"attempting to acquire leader lease pulumi-kubernetes-operator/operator.pulumi.com..."}
{"level":"info","ts":"2025-05-23T20:08:41.516Z","msg":"successfully acquired lease pulumi-kubernetes-operator/operator.pulumi.com"}

```

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #912
