### PR TITLE
Improved Flux compatibility for Stack controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ CHANGELOG
 - Update to Go 1.24 [#926](https://github.com/pulumi/pulumi-kubernetes-operator/pull/926)
 - More cloud logging options [#927](https://github.com/pulumi/pulumi-kubernetes-operator/pull/927)
 - Program status to be fully Flux-compatible [#928](https://github.com/pulumi/pulumi-kubernetes-operator/pull/928)
-- Improved Flux compatibility [#928](https://github.com/pulumi/pulumi-kubernetes-operator/pull/928)
+- Improved Flux compatibility for Stack controller [#929](https://github.com/pulumi/pulumi-kubernetes-operator/pull/929)
 
 ## 2.0.0 (2025-02-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
 - Update to Go 1.24 [#926](https://github.com/pulumi/pulumi-kubernetes-operator/pull/926)
 - More cloud logging options [#927](https://github.com/pulumi/pulumi-kubernetes-operator/pull/927)
 - Program status to be fully Flux-compatible [#928](https://github.com/pulumi/pulumi-kubernetes-operator/pull/928)
+- Improved Flux compatibility [#928](https://github.com/pulumi/pulumi-kubernetes-operator/pull/928)
 
 ## 2.0.0 (2025-02-18)
 

--- a/operator/internal/controller/auto/connect.go
+++ b/operator/internal/controller/auto/connect.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -62,6 +63,7 @@ func NewConnectionManager(config *rest.Config, opts ConnectionManagerOptions) (*
 }
 
 func (cm *ConnectionManager) Connect(ctx context.Context, w *autov1alpha1.Workspace) (*grpc.ClientConn, error) {
+	l := log.FromContext(ctx)
 	audience := audienceForWorkspace(w)
 	creds := client.NewTokenCredentials(cm.factory.TokenSource(audience))
 

--- a/operator/internal/controller/pulumi/flux.go
+++ b/operator/internal/controller/pulumi/flux.go
@@ -17,95 +17,30 @@ package pulumi
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	autov1alpha1 "github.com/pulumi/pulumi-kubernetes-operator/v2/operator/api/auto/v1alpha1"
 	"github.com/pulumi/pulumi-kubernetes-operator/v2/operator/api/pulumi/shared"
+	pulumiv1 "github.com/pulumi/pulumi-kubernetes-operator/v2/operator/api/pulumi/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-func (sess *stackReconcilerSession) SetupWorkspaceFromFluxSource(ctx context.Context, source unstructured.Unstructured, fluxSource *shared.FluxSource) (string, error) {
+func (sess *stackReconcilerSession) SetupWorkspaceFromFluxSource(ctx context.Context, source unstructured.Unstructured,
+	artifact pulumiv1.Artifact, dir string) error {
 	// this source artifact fetching code is based closely on
-	// https://github.com/fluxcd/kustomize-controller/blob/db3c321163522259595894ca6c19ed44a876976d/controllers/kustomization_controller.go#L529
-	sess.logger.V(1).Info("Setting up pulumi workspace for stack", "stack", sess.stack, "workspace", sess.ws.Name)
-
-	artifactURL, err := getArtifactField(source, "url")
-	if err != nil {
-		return "", err
-	}
-	digest, err := getArtifactField(source, "digest")
-	if err != nil {
-		return "", err
-	}
+	sess.logger.V(1).Info("Setting up pulumi workspace for stack", "stack", sess.stack, "workspace", sess.ws.Name,
+		"artifact", artifact, "dir", dir)
 
 	sess.ws.Spec.Flux = &autov1alpha1.FluxSource{
-		Url:    artifactURL,
-		Digest: digest,
-		Dir:    fluxSource.Dir,
+		Url:    artifact.URL,
+		Digest: artifact.Digest,
+		Dir:    dir,
 	}
 
-	return digest, nil
-}
-
-// getArtifactField is a helper to get a specified nested field from .status.artifact.
-func getArtifactField(source unstructured.Unstructured, field string) (string, error) {
-	value, ok, err := unstructured.NestedString(source.Object, "status", "artifact", field)
-	if !ok || err != nil || value == "" {
-		return "", fmt.Errorf("expected a non-empty string in .status.artifact.%s", field)
-	}
-	return value, nil
-}
-
-// checksumOrDigest returns the digest or checksum field from the artifact status. It prefers digest over checksum.
-func checksumOrDigest(source unstructured.Unstructured) (string, error) {
-	digest, _ := getArtifactField(source, "digest")
-	checksum, _ := getArtifactField(source, "checksum")
-
-	if digest == "" && checksum == "" {
-		return "", fmt.Errorf("expected at least one of .status.artifact.{digest,checksum} to be a non-empty string")
-	}
-
-	// Prefer digest over checksum.
-	if digest != "" {
-		// TODO: Remove normalization once we upgrade to github.com/fluxcd/pkg/http/fetch v0.5.1 or higher.
-
-		// Extract the hash from the digest (<algorithm>:<hash>). The current fetcher expects the hash only.
-		parts := strings.Split(digest, ":")
-		if len(parts) != 2 {
-			return "", fmt.Errorf("invalid digest format: %q, expected <algorithm>:<hash>", digest)
-		}
-
-		return parts[1], nil
-	}
-
-	return checksum, nil
-}
-
-func checkFluxSourceReady(obj *unstructured.Unstructured) bool {
-	observedGeneration, ok, err := unstructured.NestedInt64(obj.Object, "status", "observedGeneration")
-	if !ok || err != nil || observedGeneration != obj.GetGeneration() {
-		return false
-	}
-	conditions, ok, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
-	if !ok || err != nil {
-		return false
-	}
-	for _, c0 := range conditions {
-		var c map[string]interface{}
-		if c, ok = c0.(map[string]interface{}); !ok {
-			// condition isn't the right shape, try the next one
-			continue
-		}
-		if t, ok, err := unstructured.NestedString(c, "type"); ok && err == nil && t == "Ready" {
-			if v, ok, err := unstructured.NestedString(c, "status"); ok && err == nil && v == "True" {
-				return true
-			}
-		}
-	}
-	return false
+	return nil
 }
 
 func getSourceGVK(src shared.FluxSourceReference) (schema.GroupVersionKind, error) {
@@ -117,25 +52,53 @@ func fluxSourceKey(gvk schema.GroupVersionKind, name string) string {
 	return fmt.Sprintf("%s:%s", gvk, name)
 }
 
-type fluxSourceReadyPredicate struct{}
-
-var _ predicate.Predicate = &fluxSourceReadyPredicate{}
-
-func (fluxSourceReadyPredicate) Create(e event.CreateEvent) bool {
-	return checkFluxSourceReady(e.Object.(*unstructured.Unstructured))
+type SourceRevisionChangePredicate struct {
+	predicate.Funcs
 }
 
-func (fluxSourceReadyPredicate) Delete(_ event.DeleteEvent) bool {
-	return false
-}
-
-func (fluxSourceReadyPredicate) Update(e event.UpdateEvent) bool {
+func (SourceRevisionChangePredicate) Update(e event.UpdateEvent) bool {
 	if e.ObjectOld == nil || e.ObjectNew == nil {
 		return false
 	}
-	return !checkFluxSourceReady(e.ObjectOld.(*unstructured.Unstructured)) && checkFluxSourceReady(e.ObjectNew.(*unstructured.Unstructured))
+
+	oldSource, ok := e.ObjectOld.(*unstructured.Unstructured)
+	if !ok || oldSource == nil {
+		return false
+	}
+	oldArtifact, _, _ := getArtifact(*oldSource)
+
+	newSource, ok := e.ObjectNew.(*unstructured.Unstructured)
+	if !ok || newSource == nil {
+		return false
+	}
+	newArtifact, _, _ := getArtifact(*newSource)
+
+	if oldArtifact == nil && newArtifact != nil {
+		return true
+	}
+
+	if oldArtifact != nil && newArtifact != nil &&
+		!oldArtifact.HasRevision(newArtifact.Revision) {
+		return true
+	}
+
+	return false
 }
 
-func (fluxSourceReadyPredicate) Generic(_ event.GenericEvent) bool {
-	return false
+// getArtifact retrieves the Artifact from the given Source object.
+// It returns the Artifact, a boolean indicating if the Artifact was found,
+// and an error if there was an issue retrieving or decoding the Artifact.
+func getArtifact(source unstructured.Unstructured) (*pulumiv1.Artifact, bool, error) {
+	m, hasArtifact, err := unstructured.NestedMap(source.Object, "status", "artifact")
+	if err != nil {
+		return nil, false, err
+	}
+	if !hasArtifact {
+		return nil, false, nil
+	}
+	var artifact pulumiv1.Artifact
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(m, &artifact); err != nil {
+		return nil, false, fmt.Errorf("failed to decode artifact: %w", err)
+	}
+	return &artifact, true, nil
 }

--- a/operator/internal/controller/pulumi/flux_test.go
+++ b/operator/internal/controller/pulumi/flux_test.go
@@ -15,10 +15,17 @@
 package pulumi
 
 import (
+	"reflect"
+	"strings"
 	"testing"
+	"time"
 
+	pulumiv1 "github.com/pulumi/pulumi-kubernetes-operator/v2/operator/api/pulumi/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 // yamlToUnstructured is a helper to convert a YAML string to an unstructured object.
@@ -32,143 +39,314 @@ func yamlToUnstructured(t *testing.T, yml string) unstructured.Unstructured {
 	return unstructured.Unstructured{Object: m}
 }
 
-func TestGetArtifactField(t *testing.T) {
+var replayGitRepository = []string{`
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  generation: 1
+  name: example
+  namespace: default
+  resourceVersion: "2323206"
+spec:
+  interval: 30s
+  ref:
+    branch: main
+  timeout: 60s
+  url: https://github.com/EronWright/simple-random.git
+status:
+  observedGeneration: -1
+`, `
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  generation: 1
+  name: example
+  namespace: default
+  resourceVersion: "2323213"
+spec:
+  interval: 30s
+  ref:
+    branch: main
+  timeout: 60s
+  url: https://github.com/EronWright/simple-random.git
+status:
+  conditions:
+  - lastTransitionTime: "2025-05-28T00:45:47Z"
+    message: 'building artifact: new upstream revision ''main@sha1:9eb98f3e74333ae8abadf0d73356a1bca9d3b9de'''
+    observedGeneration: 1
+    reason: Progressing
+    status: "True"
+    type: Reconciling
+  - lastTransitionTime: "2025-05-28T00:45:47Z"
+    message: 'building artifact: new upstream revision ''main@sha1:9eb98f3e74333ae8abadf0d73356a1bca9d3b9de'''
+    observedGeneration: 1
+    reason: Progressing
+    status: Unknown
+    type: Ready
+  observedGeneration: -1
+`, `
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  generation: 1
+  name: example
+  namespace: default
+  resourceVersion: "2323215"
+spec:
+  interval: 30s
+  ref:
+    branch: main
+  timeout: 60s
+  url: https://github.com/EronWright/simple-random.git
+status:
+  conditions:
+  - lastTransitionTime: "2025-05-28T00:45:47Z"
+    message: stored artifact for revision 'main@sha1:9eb98f3e74333ae8abadf0d73356a1bca9d3b9de'
+    observedGeneration: 1
+    reason: Succeeded
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2025-05-28T00:45:47Z"
+    message: stored artifact for revision 'main@sha1:9eb98f3e74333ae8abadf0d73356a1bca9d3b9de'
+    observedGeneration: 1
+    reason: Succeeded
+    status: "True"
+    type: ArtifactInStorage
+  observedGeneration: -1
+`, `
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  generation: 1
+  name: example
+  namespace: default
+  resourceVersion: "2323216"
+spec:
+  interval: 30s
+  ref:
+    branch: main
+  timeout: 60s
+  url: https://github.com/EronWright/simple-random.git
+status:
+  artifact:
+    digest: sha256:c84370fd81474ea743d030a86b74b847c714af74d87b038de5fa41d21336e0e6
+    lastUpdateTime: "2025-05-28T00:45:47Z"
+    path: gitrepository/default/example/9eb98f3e74333ae8abadf0d73356a1bca9d3b9de.tar.gz
+    revision: main@sha1:9eb98f3e74333ae8abadf0d73356a1bca9d3b9de
+    size: 585
+    url: http://source-controller.flux-system.svc.cluster.local./gitrepository/default/example/9eb98f3e74333ae8abadf0d73356a1bca9d3b9de.tar.gz
+  conditions:
+  - lastTransitionTime: "2025-05-28T00:45:47Z"
+    message: stored artifact for revision 'main@sha1:9eb98f3e74333ae8abadf0d73356a1bca9d3b9de'
+    observedGeneration: 1
+    reason: Succeeded
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2025-05-28T00:45:47Z"
+    message: stored artifact for revision 'main@sha1:9eb98f3e74333ae8abadf0d73356a1bca9d3b9de'
+    observedGeneration: 1
+    reason: Succeeded
+    status: "True"
+    type: ArtifactInStorage
+  observedGeneration: 1
+`,
+	`
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  generation: 2
+  name: example
+  namespace: default
+  resourceVersion: "2323573"
+spec:
+  interval: 32s
+  ref:
+    branch: main
+  timeout: 60s
+  url: https://github.com/EronWright/simple-random.git
+status:
+  artifact:
+    digest: sha256:c84370fd81474ea743d030a86b74b847c714af74d87b038de5fa41d21336e0e6
+    lastUpdateTime: "2025-05-28T00:45:47Z"
+    path: gitrepository/default/example/9eb98f3e74333ae8abadf0d73356a1bca9d3b9de.tar.gz
+    revision: main@sha1:9eb98f3e74333ae8abadf0d73356a1bca9d3b9de
+    size: 585
+    url: http://source-controller.flux-system.svc.cluster.local./gitrepository/default/example/9eb98f3e74333ae8abadf0d73356a1bca9d3b9de.tar.gz
+  conditions:
+  - lastTransitionTime: "2025-05-28T00:45:47Z"
+    message: stored artifact for revision 'main@sha1:9eb98f3e74333ae8abadf0d73356a1bca9d3b9de'
+    observedGeneration: 1
+    reason: Succeeded
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2025-05-28T00:45:47Z"
+    message: stored artifact for revision 'main@sha1:9eb98f3e74333ae8abadf0d73356a1bca9d3b9de'
+    observedGeneration: 1
+    reason: Succeeded
+    status: "True"
+    type: ArtifactInStorage
+  observedGeneration: 1
+`, `
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  generation: 2
+  name: example
+  namespace: default
+  resourceVersion: "2323790"
+spec:
+  interval: 32s
+  ref:
+    branch: main
+  timeout: 60s
+  url: https://github.com/EronWright/simple-random.git
+status:
+  artifact:
+    digest: sha256:c84370fd81474ea743d030a86b74b847c714af74d87b038de5fa41d21336e0e6
+    lastUpdateTime: "2025-05-28T00:45:47Z"
+    path: gitrepository/default/example/9eb98f3e74333ae8abadf0d73356a1bca9d3b9de.tar.gz
+    revision: main@sha1:9eb98f3e74333ae8abadf0d73356a1bca9d3b9de
+    size: 585
+    url: http://source-controller.flux-system.svc.cluster.local./gitrepository/default/example/9eb98f3e74333ae8abadf0d73356a1bca9d3b9de.tar.gz
+  conditions:
+  - lastTransitionTime: "2025-05-28T00:49:21Z"
+    message: stored artifact for revision 'main@sha1:00ca386d43834c41d9626b6d93137d396fd771ed'
+    observedGeneration: 2
+    reason: Succeeded
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2025-05-28T00:49:21Z"
+    message: stored artifact for revision 'main@sha1:00ca386d43834c41d9626b6d93137d396fd771ed'
+    observedGeneration: 2
+    reason: Succeeded
+    status: "True"
+    type: ArtifactInStorage
+  observedGeneration: 2
+`, `
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  generation: 2
+  name: example
+  namespace: default
+  resourceVersion: "2323791"
+spec:
+  interval: 32s
+  ref:
+    branch: main
+  timeout: 60s
+  url: https://github.com/EronWright/simple-random.git
+status:
+  artifact:
+    digest: sha256:617e0171fd6c8d0b01c04ca9ef788b6447fab174c48411fb9a1cb857a9b4aae5
+    lastUpdateTime: "2025-05-28T00:49:21Z"
+    path: gitrepository/default/example/00ca386d43834c41d9626b6d93137d396fd771ed.tar.gz
+    revision: main@sha1:00ca386d43834c41d9626b6d93137d396fd771ed
+    size: 585
+    url: http://source-controller.flux-system.svc.cluster.local./gitrepository/default/example/00ca386d43834c41d9626b6d93137d396fd771ed.tar.gz
+  conditions:
+  - lastTransitionTime: "2025-05-28T00:49:21Z"
+    message: stored artifact for revision 'main@sha1:00ca386d43834c41d9626b6d93137d396fd771ed'
+    observedGeneration: 2
+    reason: Succeeded
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2025-05-28T00:49:21Z"
+    message: stored artifact for revision 'main@sha1:00ca386d43834c41d9626b6d93137d396fd771ed'
+    observedGeneration: 2
+    reason: Succeeded
+    status: "True"
+    type: ArtifactInStorage
+  observedGeneration: 2
+`,
+}
+
+func TestGetArtifact(t *testing.T) {
+
+	parseTime := func(s string) metav1.Time {
+		t.Helper()
+		pt, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			t.Fatalf("error parsing time %q: %v", s, err)
+		}
+		return metav1.NewTime(pt.Local())
+	}
+
 	tests := []struct {
-		name, source, field, want string
-		wantErr                   bool
+		name, source string
+		want         *pulumiv1.Artifact
+		wantErr      bool
 	}{
 		{
-			name: "Get valid field - happy path",
-			source: `apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
-metadata:
-    name: pulumi-git-repo
-spec:
-    interval: 1m
-status:
-    artifact:
-        url: http://example.com
-        revision: "1234567890"
-        checksum: "123abcdef"`,
-			field:   "checksum",
-			want:    "123abcdef",
-			wantErr: false,
+			name:   "before-reconciliation",
+			source: replayGitRepository[0],
+			want:   nil,
 		},
 		{
-			name: "Expect error for non-existent field",
-			source: `apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
-metadata:
-    name: pulumi-git-repo
-spec:
-    interval: 1m
-status:
-    artifact:
-        url: http://example.com
-        revision: "1234567890"
-        checksum: "123abcdef"`,
-			field:   "unknown",
-			wantErr: true,
+			name:   "progressing",
+			source: replayGitRepository[1],
+			want:   nil,
+		},
+		{
+			name:   "updating status",
+			source: replayGitRepository[2],
+			want:   nil,
+		},
+		{
+			name:   "ready",
+			source: replayGitRepository[3],
+			want: &pulumiv1.Artifact{
+				Digest:         "sha256:c84370fd81474ea743d030a86b74b847c714af74d87b038de5fa41d21336e0e6",
+				LastUpdateTime: parseTime("2025-05-28T00:45:47Z"),
+				Path:           "gitrepository/default/example/9eb98f3e74333ae8abadf0d73356a1bca9d3b9de.tar.gz",
+				Revision:       "main@sha1:9eb98f3e74333ae8abadf0d73356a1bca9d3b9de",
+				Size:           ptr.To(int64(585)),
+				URL:            "http://source-controller.flux-system.svc.cluster.local./gitrepository/default/example/9eb98f3e74333ae8abadf0d73356a1bca9d3b9de.tar.gz",
+			},
 		},
 	}
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			obj := yamlToUnstructured(t, tc.source)
-			got, err := getArtifactField(obj, tc.field)
+			obj := yamlToUnstructured(t, strings.TrimSpace(tc.source))
+			artifact, gotArtifact, err := getArtifact(obj)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("getField() error = %v, wantErr %v", err, tc.wantErr)
 			}
-			if got != tc.want {
-				t.Errorf("getField() = %v, want %v", got, tc.want)
+			if tc.want == nil && (gotArtifact || artifact != nil) {
+				t.Errorf("getArtifact() gotArtifact = %v, artifact = %v, want nil", gotArtifact, artifact)
+			}
+			if tc.want != nil && (artifact == nil || !reflect.DeepEqual(*artifact, *tc.want)) {
+				t.Errorf("getArtifact() = %v, want %v", artifact, tc.want)
 			}
 		})
 	}
 }
 
-func TestChecksumOrDigest(t *testing.T) {
-	tests := []struct {
-		name, source, want string
-		wantErr            bool
-	}{
-		{
-			name: "Get checksum field - happy path",
-			source: `apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
-metadata:
-    name: pulumi-git-repo
-spec:
-    interval: 1m
-status:
-    artifact:
-        url: http://example.com
-        revision: "1234567890"
-        checksum: "123abcdef"`,
-			want:    "123abcdef",
-			wantErr: false,
-		},
-		{
-			name: "Get digest field - happy path",
-			source: `apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
-metadata:
-    name: pulumi-git-repo
-spec:
-    interval: 1m
-status:
-    artifact:
-        url: http://example.com
-        revision: "1234567890"
-        digest: "sha256:123abcdef"`,
-			want:    "123abcdef",
-			wantErr: false,
-		},
-		{
-			name: "Get digest field when both digest and checksum present",
-			source: `apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
-metadata:
-    name: pulumi-git-repo
-spec:
-    interval: 1m
-status:
-    artifact:
-        url: http://example.com
-        revision: "1234567890"
-        digest: "sha256:123abcdef"
-        checksum: "1234567890"`,
-			want:    "123abcdef",
-			wantErr: false,
-		},
-		{
-			name: "Error if neither digest nor checksum present",
-			source: `apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
-metadata:
-    name: pulumi-git-repo
-spec:
-    interval: 1m
-status:
-    artifact:
-        url: http://example.com
-        revision: "1234567890"`,
-			wantErr: true,
-		},
+func TestSourceRevisionChangePredicate(t *testing.T) {
+	want := []bool{
+		false,
+		false,
+		false,
+		true, // .status.artifact is set
+		false,
+		false,
+		true, // .status.artifact is updated
 	}
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			obj := yamlToUnstructured(t, tc.source)
-			got, err := checksumOrDigest(obj)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("checksumOrDigest() error = %v, wantErr %v", err, tc.wantErr)
-				return
-			}
-			if got != tc.want {
-				t.Errorf("checksumOrDigest() = %v, want %v", got, tc.want)
-			}
+
+	var old *unstructured.Unstructured
+	for i := 0; i < len(replayGitRepository); i++ {
+		obj := yamlToUnstructured(t, strings.TrimSpace(replayGitRepository[i]))
+
+		p := SourceRevisionChangePredicate{}
+		got := p.Update(event.UpdateEvent{
+			ObjectOld: old,
+			ObjectNew: &obj,
 		})
+		if got != want[i] {
+			t.Errorf("SourceRevisionChangePredicate.Update() = %v, want %v", got, want[i])
+		}
+		old = &obj
 	}
 }


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

This PR updates how the Stack controller watches for Flux source updates, and for Program updates, to use [`SourceRevisionChangePredicate`](https://github.com/fluxcd/kustomize-controller/blob/9f784c5e9fa85073c09f709fa912d08b3823e9d3/internal/controller/source_predicate.go).  It triggers reconciliation whenever `.status.artifact` has substantively changed. The controller must immediately use the artifact regardless of the status conditions or observed generation, because further evolution of the conditions may not trigger a second reconciliation.

This PR switches over to passing the full digest value to the fetcher; previously we trimmed the algorithm component for compatibility with an old version of the fetch library. The agent log shows the digest is still usable:

```log
random-yaml-program-workspace-0 fetch 2025-05-28T23:18:47.109Z  INFO    cmd.init        flux artifact fetching  {"url": "http://pulumi-kubernetes-operator.pulumi-kubernetes-operator:80/programs/default/random-yaml/1", "digest": "sha256:253d4f28b6aaa683ae86167b525d76db2e6db39a96a324cdb0c569d36deffd74"}
random-yaml-program-workspace-0 fetch 2025-05-28T23:18:47.112Z  INFO    cmd.init        flux artifact fetched   {"dir": "/share/source"}
```

This PR makes a minor breaking API change, to use the artifact's _revision_ (rather than digest) as the value for `.status.lastSuccessfulCommit`. A Flux revision is defined as per below, and is clearly more useful and commit-like:
```
// Revision is a human-readable identifier traceable in the origin source
// system. It can be a Git commit SHA, Git tag, a Helm chart version, etc.
```

The result is a more readable value for `lastSuccessfulCommit`. Shown below is two different stacks, flux- and program-based, and how their artifact's revision become the value of `lastSuccessfulCommit`.

```yaml
apiVersion: pulumi.com/v1
kind: Stack
metadata:
  generation: 1
  name: random-yaml-flux
status:
 lastUpdate:
    generation: 1
    lastAttemptedCommit: master@sha1:b2a63a2a9f640882d06f201e26049104e0af3326
    lastResyncTime: "2025-05-28T23:09:02Z"
    lastSuccessfulCommit: master@sha1:b2a63a2a9f640882d06f201e26049104e0af3326
    name: random-yaml-flux-1971927ddbc
    permalink: https://app.pulumi.com/eron-pulumi-corp/random/random-yaml-flux/updates/3
    state: succeeded
    type: up
---
apiVersion: pulumi.com/v1
kind: Stack
metadata:
  generation: 1
  name: random-yaml-program
status:
  lastUpdate:
    generation: 1
    lastAttemptedCommit: "8"
    lastResyncTime: "2025-05-29T05:58:45Z"
    lastSuccessfulCommit: "8"
    name: random-yaml-program-1971a9f1228
    permalink: https://app.pulumi.com/eron-pulumi-corp/random-yaml/random-yaml-program/updates/8
    state: succeeded
    type: up
```

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
