### PR TITLE
implement dynamic environment variables

### DIFF
--- a/examples/custom-workspace/workspace.yaml
+++ b/examples/custom-workspace/workspace.yaml
@@ -37,6 +37,7 @@ spec:
   # - pod tolerations
   # - extra init container(s)
   # - extra volume(s) and volume mounts onto the 'pulumi' container
+  # - dynamic environment variables passed to the pulumi CLI
   podTemplate:
     metadata:
       labels:
@@ -50,7 +51,12 @@ spec:
       initContainers:
         - name: extra
           image: busybox
-          command: ["sh", "-c", "echo 'Hello, extra init container!'"]
+          command:
+            - sh
+            - -c
+            - |
+                echo 'Hello, extra init container!'
+                echo 'PULUMI_CONFIG_PASSPHRASE=test' > /share/.env
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/operator/e2e/e2e_test.go
+++ b/operator/e2e/e2e_test.go
@@ -211,6 +211,17 @@ func TestE2E(t *testing.T) {
 				assert.False(t, found)
 			},
 		},
+		{
+			name: "issue-937",
+			f: func(t *testing.T) {
+				cmd := exec.Command("kubectl", "apply", "-f", "e2e/testdata/issue-937")
+				require.NoError(t, run(cmd))
+				dumpLogs(t, "issue-937", "pod/issue-937-workspace-0")
+
+				_, err := waitFor[pulumiv1.Stack]("stacks/issue-937", "issue-937", 5*time.Minute, "condition=Ready")
+				require.NoError(t, err)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/operator/e2e/testdata/issue-937/manifests.yaml
+++ b/operator/e2e/testdata/issue-937/manifests.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: issue-937
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: issue-937
+  namespace: issue-937
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: issue-937:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: issue-937
+  namespace: issue-937
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: issue-937-state
+  namespace: issue-937
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: pulumi.com/v1
+kind: Stack
+metadata:
+  name: issue-937
+  namespace: issue-937
+spec:
+  projectRepo: https://github.com/pulumi/examples
+  commit: 1e2fc471709448f3c9f7a250f28f1eafcde7017b
+  shallow: true
+  repoDir: random-yaml/
+
+  stack: issue-937
+  refresh: false
+  continueResyncOnCommitMatch: false
+  resyncFrequencySeconds: 60
+  destroyOnFinalize: false
+
+  # Enable file state for testing.
+  envRefs:
+    PULUMI_BACKEND_URL:
+      type: Literal
+      literal:
+        value: "file:///state/"
+    # note: PULUMI_CONFIG_PASSPHRASE is set dynamically in the workspace template.
+  workspaceTemplate:
+    spec:
+      image: pulumi/pulumi:3.147.0-nonroot
+      serviceAccountName: issue-937
+      podTemplate:
+        spec:
+          initContainers:
+            - name: extra
+              image: busybox
+              command:
+                - sh
+                - -c
+                - |
+                    echo 'PULUMI_CONFIG_PASSPHRASE=test' > /share/.env
+                    echo 'Wrote dynamic environment variables'
+              volumeMounts:
+                - name: share
+                  mountPath: /share
+          containers:
+            - name: pulumi
+              volumeMounts:
+                - name: state
+                  mountPath: /state
+          volumes:
+            - name: state
+              persistentVolumeClaim:
+                claimName: issue-937-state


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Implements the suggested solution to automatically read an environment file (`/share/.env`) into the pulumi container, to be able to dynamically set environment variables affecting the Pulumi CLI and your program and to configure providers.

Unlike variables set thru the Stack spec, these variables are set by init containers by writing to the environment file.  For example:

```yaml
initContainers:
  - name: extra
    image: busybox
    command:
      - sh
      - -c
      - |
          echo 'PULUMI_CONFIG_PASSPHRASE=test' > /share/.env
```

### Testing

A new e2e test was developed.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->

Closes #937 
