### PR TITLE
Fix Helm chart version for v2.3.0 release

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -7,14 +7,18 @@ Prepare a new release of the pulumi-kubernetes-operator by:
 1. Ask the user for the release version (e.g., v2.3.0)
 2. Run `make prep RELEASE=<version>` to update version strings across the codebase
 3. Review the changes made by the prep command
-4. Create a commit with message "Prepare release <version>"
-5. Guide the user to:
+4. **IMPORTANT: Manual Helm Chart Updates** - The `make prep` command does NOT update these fields:
+   - Update the `version` field in `deploy/helm/pulumi-operator/Chart.yaml` (e.g., from "2.2.0" to "2.3.0" - note: no 'v' prefix)
+   - Update the version badge in `deploy/helm/pulumi-operator/README.md` line 3 (e.g., `![Version: 2.2.0]` to `![Version: 2.3.0]`)
+5. Update CHANGELOG.md by moving unreleased items to a new release section
+6. Create a commit with message "Prepare release <version>"
+7. Guide the user to:
    - Open a PR with the changes
    - After the PR is merged, tag the release with `git tag <version>` and `git push origin <version>`
    - This will trigger the release workflow (.github/workflows/release.yaml)
    - The workflow will create a GitHub release with a draft of the release notes
-6. Once the draft release is created, fetch the list of merged PRs since the last release
-7. Generate a "What's New" section summarizing the key changes from the PRs
-8. Guide the user to update the GitHub release notes with the "What's New" section
+8. Once the draft release is created, fetch the list of merged PRs since the last release
+9. Generate a "What's New" section summarizing the key changes from the PRs
+10. Guide the user to update the GitHub release notes with the "What's New" section
 
 Ask the user for the version number now.

--- a/deploy/helm/pulumi-operator/Chart.yaml
+++ b/deploy/helm/pulumi-operator/Chart.yaml
@@ -9,7 +9,7 @@ icon: https://www.pulumi.com/logos/brand/avatar-on-white.svg
 
 type: application
 
-version: "2.2.0"
+version: "2.3.0"
 appVersion: "v2.3.0"
 
 keywords:


### PR DESCRIPTION
## Summary

Fixes the Helm chart version field that was missed in the v2.3.0 release preparation.

## Changes

- Update `Chart.yaml` version field from "2.2.0" to "2.3.0"
- Update `/release` command to document manual Helm chart update steps

## Background

The `make prep` command only updates fields matching the pattern with a 'v' prefix (e.g., "v2.2.0"), so it misses:
- `Chart.yaml` version field (uses "2.2.0" format without 'v')
- `README.md` version badge (already fixed in #1043)

This caused the chart-publish job to fail when trying to create a release for the existing chart version "2.2.0".

## Next Steps

After merging:
1. Delete the v2.3.0 tag: `git tag -d v2.3.0 && git push origin :refs/tags/v2.3.0`
2. Re-tag from the updated master: `git tag v2.3.0 && git push origin v2.3.0`
3. The release workflow will run again with the correct chart version

🤖 Generated with [Claude Code](https://claude.com/claude-code)