### PR TITLE
Fix race condition with Update finalizers using SSA

### DIFF
--- a/operator/migrations/cleanup-orphaned-updates.sh
+++ b/operator/migrations/cleanup-orphaned-updates.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# cleanup-orphaned-updates.sh
+#
+# Cleans up orphaned Update objects that have:
+# - A deletionTimestamp set (marked for deletion)
+# - The finalizer.stack.pulumi.com finalizer still present (blocking deletion)
+#
+# This is a temporary workaround for issue #1060 where a race condition
+# can leave Update objects stuck with finalizers that were never removed.
+
+set -euo pipefail
+
+FINALIZER="finalizer.stack.pulumi.com"
+DRY_RUN="${DRY_RUN:-true}"
+
+echo "Scanning for orphaned Update objects..."
+echo "DRY_RUN=$DRY_RUN (set DRY_RUN=false to actually remove finalizers)"
+echo ""
+
+# Get all Updates across all namespaces that have deletionTimestamp set and our finalizer
+ORPHANED_UPDATES=$(kubectl get updates.auto.pulumi.com --all-namespaces -o json | \
+  jq -r '.items[] | select(.metadata.deletionTimestamp != null) | select(.metadata.finalizers[]? == "'"$FINALIZER"'") | "\(.metadata.namespace)/\(.metadata.name)"')
+
+if [ -z "$ORPHANED_UPDATES" ]; then
+  echo "No orphaned Update objects found."
+  exit 0
+fi
+
+echo "Found orphaned Update objects:"
+echo "$ORPHANED_UPDATES"
+echo ""
+
+for UPDATE in $ORPHANED_UPDATES; do
+  NAMESPACE=$(echo "$UPDATE" | cut -d'/' -f1)
+  NAME=$(echo "$UPDATE" | cut -d'/' -f2)
+
+  echo "Processing: $NAMESPACE/$NAME"
+
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "  [DRY RUN] Would remove finalizers"
+  else
+    echo "  Removing finalizers..."
+    kubectl patch update.auto.pulumi.com "$NAME" -n "$NAMESPACE" --type=merge \
+      -p '{"metadata":{"finalizers":null}}'
+    echo "  Done."
+  fi
+done
+
+echo ""
+if [ "$DRY_RUN" = "true" ]; then
+  echo "Dry run complete. Run with DRY_RUN=false to actually clean up."
+else
+  echo "Cleanup complete."
+fi


### PR DESCRIPTION
## Summary

Fixes #1060 - Race condition where TTL expiration on Update objects causes finalizer cleanup to fail.

Uses Server-Side Apply (SSA) with a dedicated field manager for the Stack controller's finalizer on Update objects. This eliminates conflicts with the Update controller's TTL deletion and prevents orphaned finalizers.

## Key Changes

- **`StackFinalizerFieldManager`**: New field manager (`pulumi-kubernetes-operator/stack-finalizer`) for SSA-based finalizer management
- **Blind SSA applies**: No resourceVersion conflicts - just apply desired state
- **Best-effort removal**: Finalizer removal logs errors but doesn't fail the reconcile (status already saved)
- **Migration detection**: Logs warning with kubectl remediation for legacy objects
- **Cleanup script**: `migrations/cleanup-orphaned-updates.sh` for users with stuck Update objects

## How It Works

Kubernetes finalizers use `listType=set`, meaning each finalizer entry is individually owned by field managers. By using a dedicated field manager for the Stack controller's finalizer:

1. **Adding finalizer**: SSA apply with the finalizer using `StackFinalizerFieldManager`
2. **Removing finalizer**: SSA apply with **no finalizers** using the same field manager → releases ownership, finalizer is removed

This is a "blind apply" - no need to read current state or handle conflicts.

## Migration

Existing Update objects have finalizers owned by the old field manager. The SSA removal won't affect these, so:
- A warning is logged with a kubectl one-liner for manual remediation
- The cleanup script can be used to remove stuck finalizers in bulk
- New Update objects use the correct field manager going forward

## Test plan

- [x] Unit tests for `addUpdateFinalizer`, `removeUpdateFinalizer`, and `isFinalizerOwnedByLegacyManager`
- [x] All existing tests pass (98 specs)
- [ ] Manual testing with TTL-triggered deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)