### PR TITLE
feat(helm): add configurable metrics-secure flag

### DIFF
--- a/deploy/helm/pulumi-operator/README.md
+++ b/deploy/helm/pulumi-operator/README.md
@@ -34,7 +34,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | The affinity constraint |
+| controller.logFormat | string | `"console"` | Log format (one of 'json' or 'console') |
 | controller.logLevel | string | `"info"` | Log Level ('debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity) |
+| controller.metricsSecure | bool | `true` | Enable secure metrics endpoint (requires TLS configuration) |
 | deploymentAnnotations | object | `{}` | Deployment annotations |
 | deploymentStrategy | string | `""` | Specifies the strategy used to replace old Pods by new ones, default: `RollingUpdate` |
 | extraEnv | list | `[]` | Extra Environments to be passed to the operator |

--- a/deploy/helm/pulumi-operator/templates/deployment.yaml
+++ b/deploy/helm/pulumi-operator/templates/deployment.yaml
@@ -38,6 +38,7 @@ spec:
         - --leader-elect
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8383
+        - --metrics-secure={{ .Values.controller.metricsSecure }}
         - --program-fs-adv-addr={{ include "pulumi-kubernetes-operator.advertisedAddress" . }}:80
         - --zap-log-level={{ .Values.controller.logLevel }}
         - --zap-encoder={{ .Values.controller.logFormat }}

--- a/deploy/helm/pulumi-operator/values.yaml
+++ b/deploy/helm/pulumi-operator/values.yaml
@@ -25,6 +25,8 @@ controller:
   logLevel: info
   # -- Log format (one of 'json' or 'console')
   logFormat: console
+  # -- Enable secure metrics endpoint (requires TLS configuration)
+  metricsSecure: true
   # -- the advertised address for the controller's service
   # advertisedAddress: "pulumi-kubernetes-operator.pulumi-kubernetes-operator.svc.cluster.local"
 


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for Pulumi's contribution guidelines.

    Help us merge your changes more quickly by adding more details such
    as labels, milestones, and reviewers.-->

### Proposed changes

<!--Give us a brief description of what you've done and what it solves. -->

Add `controller.metricsSecure` value (default: true) to allow users to configure the
`--metrics-secure` argument. Update deployment template and documentation accordingly.

Additionally updating documentation for missing configuration option `controller.logFormat`.

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other GitHub repositories. -->
n/a