### PR TITLE
Prepare release v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ CHANGELOG
 
 ## Unreleased
 
+## 2.5.1 (2026-03-03)
+
+- Various security and dependency updates
+
 ## 2.5.0 (2026-02-19)
 
 - Mark workspace as stalled instead of deleting pod on init failure [#1107](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1107)

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ A simple "quickstart" installation manifest is provided for non-production envir
 Install with `kubectl`:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/pulumi/pulumi-kubernetes-operator/refs/tags/v2.5.0/deploy/quickstart/install.yaml
+kubectl apply -f https://raw.githubusercontent.com/pulumi/pulumi-kubernetes-operator/refs/tags/v2.5.1/deploy/quickstart/install.yaml
 ```
 
 ### From Source
 
 To build and install the operator from this repository:
 
-1. Build the operator image: `make build-image` (produces `pulumi/pulumi-kubernetes-operator:v2.5.0`).
+1. Build the operator image: `make build-image` (produces `pulumi/pulumi-kubernetes-operator:v2.5.1`).
 2. Push or load the image into your cluster's registry.
 3. Deploy to your current cluster context: `make deploy`.
 

--- a/agent/version/version.go
+++ b/agent/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-var Version string = "v2.5.0"
+var Version string = "v2.5.1"

--- a/deploy/deploy-operator-yaml/Pulumi.yaml
+++ b/deploy/deploy-operator-yaml/Pulumi.yaml
@@ -5,7 +5,7 @@ description: |
 config:
   version: # The version to install of the Pulumi Kubernetes Operator.
     type: string
-    default: v2.5.0
+    default: v2.5.1
 resources:
   pko:
     type: kubernetes:kustomize/v2:Directory

--- a/deploy/helm/pulumi-operator/Chart.yaml
+++ b/deploy/helm/pulumi-operator/Chart.yaml
@@ -9,8 +9,8 @@ icon: https://www.pulumi.com/logos/brand/avatar-on-white.svg
 
 type: application
 
-version: "2.5.0"
-appVersion: "v2.5.0"
+version: "2.5.1"
+appVersion: "v2.5.1"
 
 keywords:
   - pulumi
@@ -32,7 +32,7 @@ annotations:
     - New operator version
   artifacthub.io/images: |
     - name: pulumi-kubernetes-operator
-      image: docker.io/pulumi/pulumi-kubernetes-operator:v2.5.0
+      image: docker.io/pulumi/pulumi-kubernetes-operator:v2.5.1
       platforms:
         - linux/amd64
         - linux/arm64

--- a/deploy/helm/pulumi-operator/README.md
+++ b/deploy/helm/pulumi-operator/README.md
@@ -1,6 +1,6 @@
 # Pulumi Kubernetes Operator - Helm Chart
 
-![Version: 2.4.1](https://img.shields.io/badge/Version-2.4.1-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: v2.5.0](https://img.shields.io/badge/AppVersion-v2.5.0-informational?style=for-the-badge)
+![Version: 2.5.1](https://img.shields.io/badge/Version-2.5.1-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: v2.5.1](https://img.shields.io/badge/AppVersion-v2.5.1-informational?style=for-the-badge)
 
 ## Description 📜
 

--- a/deploy/quickstart/install.yaml
+++ b/deploy/quickstart/install.yaml
@@ -30573,7 +30573,7 @@ spec:
           value: 10s
         - name: KUBE_API_TIMEOUT
           value: 30s
-        image: pulumi/pulumi-kubernetes-operator:v2.5.0
+        image: pulumi/pulumi-kubernetes-operator:v2.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= v2.5.0
+VERSION ?= v2.5.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 images:
 - name: controller
   newName: pulumi/pulumi-kubernetes-operator
-  newTag: v2.5.0
+  newTag: v2.5.1
 resources:
 - manager.yaml

--- a/operator/version/version.go
+++ b/operator/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-var Version string = "v2.5.0"
+var Version string = "v2.5.1"


### PR DESCRIPTION
## Summary
- Bump version strings to v2.5.1 across the codebase
- Update CHANGELOG with v2.5.1 release notes
- Fix stale Helm chart version badge in README (was 2.4.1)

## Release checklist
- [ ] Merge this PR
- [ ] Tag: `git tag v2.5.1 && git push origin v2.5.1`
- [ ] Verify release workflow creates draft GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)