### PR TITLE
fix: make prep target replaces bare version in helm README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ prep: ## Prepare the next release (use RELEASE=<next-tag>).
 	sed -i '' -e "s|$(CURRENT_RELEASE)|$(RELEASE)|g" deploy/helm/pulumi-operator/Chart.yaml
 	sed -i '' -e "s|$(CURRENT_RELEASE:v%=%)|$(RELEASE:v%=%)|g" deploy/helm/pulumi-operator/Chart.yaml
 	sed -i '' -e "s|$(CURRENT_RELEASE)|$(RELEASE)|g" deploy/helm/pulumi-operator/README.md
+	sed -i '' -e "s|$(CURRENT_RELEASE:v%=%)|$(RELEASE:v%=%)|g" deploy/helm/pulumi-operator/README.md
 
 .PHONY: version
 version:


### PR DESCRIPTION
## Summary
- The helm README badge contains version strings without the `v` prefix (e.g. `Version-2.5.1`), which `make prep` missed because `CURRENT_RELEASE` includes the `v`.
- Adds a `$(CURRENT_RELEASE:v%=%)` substitution for the README, matching what's already done for `Chart.yaml`.

## Test plan
- [x] Ran `make prep RELEASE=v99.99.99` and verified all version refs in `deploy/helm/pulumi-operator/README.md` were updated (no stale versions).

## Changelog
- fix: `make prep` now correctly updates bare (non-`v`-prefixed) version strings in the helm chart README

🤖 Generated with [Claude Code](https://claude.com/claude-code)