### PR TITLE
fix: pre-load Pulumi base images into Kind for e2e tests

### DIFF
--- a/operator/e2e/e2e_test.go
+++ b/operator/e2e/e2e_test.go
@@ -60,8 +60,23 @@ func TestE2E(t *testing.T) {
 	cmd := exec.Command("make", "docker-build", "VERSION="+tag)
 	require.NoError(t, run(cmd), "failed to build image")
 
-	err := loadImageToKindClusterWithName(projectimage)
-	require.NoError(t, err, "failed to load image into kind")
+	// Pre-pull Pulumi base images used by test fixtures and load all images
+	// into the Kind cluster. This avoids image-pull delays during tests which
+	// can cause timeouts, especially on resource-constrained CI nodes.
+	for _, img := range []string{
+		"pulumi/pulumi:3.202.0-nonroot",
+		"pulumi/pulumi:3.197.0-nonroot",
+	} {
+		cmd = exec.Command("docker", "pull", img)
+		require.NoError(t, run(cmd), "failed to pull %s", img)
+	}
+	for _, img := range []string{
+		projectimage,
+		"pulumi/pulumi:3.202.0-nonroot",
+		"pulumi/pulumi:3.197.0-nonroot",
+	} {
+		require.NoError(t, loadImageToKindClusterWithName(img), "failed to load %s into kind", img)
+	}
 
 	cmd = exec.Command("make", "install")
 	require.NoError(t, run(cmd), "failed to install CRDs")


### PR DESCRIPTION
## Summary
- The `structured-config-version` e2e test was flaking with a 5-minute timeout because `pulumi/pulumi:3.197.0-nonroot` had to be pulled from Docker Hub at pod creation time, late in the test suite when the Kind cluster was already under load.
- Pre-pull all Pulumi base images used by test fixtures (`3.202.0-nonroot`, `3.197.0-nonroot`) and load them into Kind alongside the operator image before tests run.
- Refactors the existing operator image load into the same loop for consistency.

## Test plan
- [ ] E2e tests pass in CI (this PR is specifically targeted at reducing flakiness of `structured-config-version`)

## Changelog
- fix: pre-load Pulumi base images into Kind cluster before e2e tests to prevent image-pull timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)