### PR TITLE
Fix destroyOnFinalize silently skipping pulumi destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## Unreleased
 
+- Fix `destroyOnFinalize: true` silently skipping `pulumi destroy` for any Stack that had been successfully reconciled [#1223](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1223)
+
 ## 2.7.0 (2026-04-06)
 
 - Add GitHub App authentication for git sources [#1167](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1167)

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -1176,7 +1176,7 @@ func isSynced(log logr.Logger, recorder record.EventRecorder, stack *pulumiv1.St
 	}
 
 	if stack.Status.LastUpdate.State == shared.SucceededStackStateMessage {
-		if stack.DeletionTimestamp != nil { // Marked for deletion (and has already been destroyed).
+		if stack.DeletionTimestamp != nil && stack.Status.LastUpdate.Type == autov1alpha1.DestroyType {
 			return true, ""
 		}
 		if stack.Status.LastUpdate.LastSuccessfulCommit != currentCommit {

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -1176,8 +1176,13 @@ func isSynced(log logr.Logger, recorder record.EventRecorder, stack *pulumiv1.St
 	}
 
 	if stack.Status.LastUpdate.State == shared.SucceededStackStateMessage {
-		if stack.DeletionTimestamp != nil && stack.Status.LastUpdate.Type == autov1alpha1.DestroyType {
-			return true, ""
+		if stack.DeletionTimestamp != nil {
+			if stack.Status.LastUpdate.Type == autov1alpha1.DestroyType {
+				return true, ""
+			}
+			msg := "Stack marked for deletion"
+			emitEvent(recorder, stack, pulumiv1.StackUpdateDetectedEvent(), msg)
+			return false, msg
 		}
 		if stack.Status.LastUpdate.LastSuccessfulCommit != currentCommit {
 			log.V(1).Info("Not synced: new commit", "current", currentCommit, "last", stack.Status.LastUpdate.LastSuccessfulCommit)

--- a/operator/internal/controller/pulumi/stack_controller_test.go
+++ b/operator/internal/controller/pulumi/stack_controller_test.go
@@ -2062,12 +2062,28 @@ func TestIsSynced(t *testing.T) {
 			wantMessage: "Stack marked for deletion",
 		},
 		{
-			name: "marked for deletion",
+			name: "marked for deletion after successful up (destroy still needs to run)",
 			stack: pulumiv1.Stack{
 				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: ptr.To(metav1.Now())},
 				Status: pulumiv1.StackStatus{
 					LastUpdate: &shared.StackUpdateState{
 						State:                shared.SucceededStackStateMessage,
+						Type:                 autov1alpha1.UpType,
+						LastSuccessfulCommit: "something-else",
+					},
+				},
+			},
+			want:        false,
+			wantMessage: "New commit detected: \"\"",
+		},
+		{
+			name: "marked for deletion after successful destroy (safe to finalize)",
+			stack: pulumiv1.Stack{
+				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: ptr.To(metav1.Now())},
+				Status: pulumiv1.StackStatus{
+					LastUpdate: &shared.StackUpdateState{
+						State:                shared.SucceededStackStateMessage,
+						Type:                 autov1alpha1.DestroyType,
 						LastSuccessfulCommit: "something-else",
 					},
 				},

--- a/operator/internal/controller/pulumi/stack_controller_test.go
+++ b/operator/internal/controller/pulumi/stack_controller_test.go
@@ -2062,19 +2062,34 @@ func TestIsSynced(t *testing.T) {
 			wantMessage: "Stack marked for deletion",
 		},
 		{
-			name: "marked for deletion after successful up (destroy still needs to run)",
+			name: "marked for deletion after successful up, matching commit (destroy still needs to run)",
 			stack: pulumiv1.Stack{
 				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: ptr.To(metav1.Now())},
 				Status: pulumiv1.StackStatus{
 					LastUpdate: &shared.StackUpdateState{
 						State:                shared.SucceededStackStateMessage,
 						Type:                 autov1alpha1.UpType,
-						LastSuccessfulCommit: "something-else",
+						LastSuccessfulCommit: "abc",
+					},
+				},
+			},
+			currentCommit: "abc",
+			want:          false,
+			wantMessage:   "Stack marked for deletion",
+		},
+		{
+			name: "marked for deletion after successful up, no source (LastSuccessfulCommit and currentCommit both empty)",
+			stack: pulumiv1.Stack{
+				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: ptr.To(metav1.Now())},
+				Status: pulumiv1.StackStatus{
+					LastUpdate: &shared.StackUpdateState{
+						State: shared.SucceededStackStateMessage,
+						Type:  autov1alpha1.UpType,
 					},
 				},
 			},
 			want:        false,
-			wantMessage: "New commit detected: \"\"",
+			wantMessage: "Stack marked for deletion",
 		},
 		{
 			name: "marked for deletion after successful destroy (safe to finalize)",
@@ -2084,12 +2099,13 @@ func TestIsSynced(t *testing.T) {
 					LastUpdate: &shared.StackUpdateState{
 						State:                shared.SucceededStackStateMessage,
 						Type:                 autov1alpha1.DestroyType,
-						LastSuccessfulCommit: "something-else",
+						LastSuccessfulCommit: "abc",
 					},
 				},
 			},
-			want:        true,
-			wantMessage: "",
+			currentCommit: "abc",
+			want:          true,
+			wantMessage:   "",
 		},
 		{
 			name: "last update succeeeded but a new commit is available",


### PR DESCRIPTION
## Summary

Fixes #1220.

`isSynced()` in the Stack controller had a fast-path that returned `true` for any stack marked for deletion whose last update succeeded — regardless of whether that update was an `up` or a `destroy`. After any successful `up`, the very first delete reconcile took the "already destroyed, finalize now" branch (`stack_controller.go:805-812`) and removed the finalizer without ever creating a Destroy Update CR. Cloud resources were silently orphaned.

The fix requires `LastUpdate.Type == autov1alpha1.DestroyType` for the deletion fast-path. If the last update was an `up`, `isSynced()` now correctly returns `false`, so the reconcile falls through to `newDestroy()` and `pulumi destroy` runs as expected.

## Test plan

- [x] `TestIsSynced` — split the existing "marked for deletion" case into two cases that exercise both the post-`up` (must run destroy) and post-`destroy` (safe to finalize) paths. Both pass.
- [x] Full Ginkgo `DestroyOnFinalize` suite (91/91 specs) in `operator/internal/controller/pulumi` passes.
- [ ] Manual verification against a live cluster: create a Stack with `destroyOnFinalize: true`, let it reconcile, delete it, confirm `pulumi destroy` runs and resources are removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)