### PR TITLE
Surface a Stalled condition when a Stack can't be destroyed in a terminating namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
 - Fix `destroyOnFinalize: true` getting stuck in `Stalled / SourceUnavailable` when a Stack is deleted together with its source (an inline `Program` or a Flux source); the operator now destroys from backend state without re-fetching the source [#1222](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1222) [#441](https://github.com/pulumi/pulumi-kubernetes-operator/issues/441)
 - Re-generate shipped CRDs and docs to match `config/crd/bases`, and add a CI gate that fails on codegen drift [#1252](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1252)
 - Bound update retries: after repeated failures a Stack is marked `Stalled` and stops retrying until its spec or source changes [#1007](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1007)
+- Surface a `Stalled / NamespaceTerminating` condition (with manual-recovery instructions) and retain the finalizer, when a `destroyOnFinalize` Stack cannot be destroyed because its namespace is terminating — instead of hanging silently or orphaning resources [#1181](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1181)
 
 ## 2.7.0 (2026-04-06)
 

--- a/deploy/crds/pulumi.com_stacks.yaml
+++ b/deploy/crds/pulumi.com_stacks.yaml
@@ -139,8 +139,10 @@ spec:
                   When enabled, the resync frequency is controlled by ResyncFrequencySeconds (default 60s).
                 type: boolean
               destroyOnFinalize:
-                description: (optional) DestroyOnFinalize can be set to true to destroy
-                  the stack completely upon deletion of the Stack custom resource.
+                description: |-
+                  (optional) DestroyOnFinalize can be set to true to destroy the stack completely upon deletion of the Stack custom resource.
+                  NOTE: destroy runs in a workspace pod, which cannot be created in a Terminating namespace; delete the Stack's
+                  namespace separately or destroy can deadlock and orphan resources. See the troubleshooting guide for recovery.
                 type: boolean
               envRefs:
                 additionalProperties:
@@ -10748,8 +10750,10 @@ spec:
                   When enabled, the resync frequency is controlled by ResyncFrequencySeconds (default 60s).
                 type: boolean
               destroyOnFinalize:
-                description: (optional) DestroyOnFinalize can be set to true to destroy
-                  the stack completely upon deletion of the Stack custom resource.
+                description: |-
+                  (optional) DestroyOnFinalize can be set to true to destroy the stack completely upon deletion of the Stack custom resource.
+                  NOTE: destroy runs in a workspace pod, which cannot be created in a Terminating namespace; delete the Stack's
+                  namespace separately or destroy can deadlock and orphan resources. See the troubleshooting guide for recovery.
                 type: boolean
               envRefs:
                 additionalProperties:

--- a/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
+++ b/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
@@ -139,8 +139,10 @@ spec:
                   When enabled, the resync frequency is controlled by ResyncFrequencySeconds (default 60s).
                 type: boolean
               destroyOnFinalize:
-                description: (optional) DestroyOnFinalize can be set to true to destroy
-                  the stack completely upon deletion of the Stack custom resource.
+                description: |-
+                  (optional) DestroyOnFinalize can be set to true to destroy the stack completely upon deletion of the Stack custom resource.
+                  NOTE: destroy runs in a workspace pod, which cannot be created in a Terminating namespace; delete the Stack's
+                  namespace separately or destroy can deadlock and orphan resources. See the troubleshooting guide for recovery.
                 type: boolean
               envRefs:
                 additionalProperties:
@@ -10748,8 +10750,10 @@ spec:
                   When enabled, the resync frequency is controlled by ResyncFrequencySeconds (default 60s).
                 type: boolean
               destroyOnFinalize:
-                description: (optional) DestroyOnFinalize can be set to true to destroy
-                  the stack completely upon deletion of the Stack custom resource.
+                description: |-
+                  (optional) DestroyOnFinalize can be set to true to destroy the stack completely upon deletion of the Stack custom resource.
+                  NOTE: destroy runs in a workspace pod, which cannot be created in a Terminating namespace; delete the Stack's
+                  namespace separately or destroy can deadlock and orphan resources. See the troubleshooting guide for recovery.
                 type: boolean
               envRefs:
                 additionalProperties:

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -165,7 +165,9 @@ When enabled, the resync frequency is controlled by ResyncFrequencySeconds (defa
         <td><b>destroyOnFinalize</b></td>
         <td>boolean</td>
         <td>
-          (optional) DestroyOnFinalize can be set to true to destroy the stack completely upon deletion of the Stack custom resource.<br/>
+          (optional) DestroyOnFinalize can be set to true to destroy the stack completely upon deletion of the Stack custom resource.
+NOTE: destroy runs in a workspace pod, which cannot be created in a Terminating namespace; delete the Stack's
+namespace separately or destroy can deadlock and orphan resources. See the troubleshooting guide for recovery.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -21911,7 +21913,9 @@ When enabled, the resync frequency is controlled by ResyncFrequencySeconds (defa
         <td><b>destroyOnFinalize</b></td>
         <td>boolean</td>
         <td>
-          (optional) DestroyOnFinalize can be set to true to destroy the stack completely upon deletion of the Stack custom resource.<br/>
+          (optional) DestroyOnFinalize can be set to true to destroy the stack completely upon deletion of the Stack custom resource.
+NOTE: destroy runs in a workspace pod, which cannot be created in a Terminating namespace; delete the Stack's
+namespace separately or destroy can deadlock and orphan resources. See the troubleshooting guide for recovery.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -89,3 +89,35 @@ a policy must be configured to allow the above traffic. Apply this manifest: [op
 On rare occasion, your Pulumi stack may become locked in the state backend. To unlock your stack:
 1. Get a shell to your workspace pod (see above).
 2. Run `pulumi cancel`.
+
+### Stack Deletion Hangs When the Namespace Is Terminating
+
+A Stack with `destroyOnFinalize: true` runs `pulumi destroy` in a workspace pod before its finalizer is
+removed. Kubernetes will not create new objects — including that workspace pod — in a namespace that is
+`Terminating`.
+
+The Stack reports a `Stalled` condition with reason `NamespaceTerminating`, whose message includes the recovery steps 
+below.
+
+```bash
+kubectl describe stack $STACK_NAME -n $NAMESPACE
+# or, just the message:
+kubectl get stack $STACK_NAME -n $NAMESPACE \
+  -o jsonpath='{.status.conditions[?(@.type=="Stalled")].message}'
+```
+
+**Recommended pattern:** do not bundle the Namespace with the Stacks that live in it, so that deleting the workload 
+removes the Stack first and lets `pulumi destroy` complete before the namespace is torn down.
+
+**Recovering a stuck Stack:** the cloud resources were never destroyed, so you must clean them up yourself and then
+release the Stack so the namespace can finish terminating:
+
+1. Destroy the resources manually — for example, run `pulumi destroy` against the same backend stack from your
+   workstation, or delete them in the cloud provider. The permalink in the Stack's stalled message (also at
+   `.status.lastUpdate.permalink`) points at the backend stack.
+2. Remove the finalizer so Kubernetes can delete the Stack:
+
+```bash
+kubectl patch stack $STACK_NAME -n $NAMESPACE --type=merge -p '{"metadata":{"finalizers":[]}}'
+```
+

--- a/operator/api/pulumi/shared/stack_types.go
+++ b/operator/api/pulumi/shared/stack_types.go
@@ -132,6 +132,8 @@ type StackSpec struct {
 	// (e.g., metadata, timestamps).
 	ExpectNoRefreshChanges bool `json:"expectNoRefreshChanges,omitempty"`
 	// (optional) DestroyOnFinalize can be set to true to destroy the stack completely upon deletion of the Stack custom resource.
+	// NOTE: destroy runs in a workspace pod, which cannot be created in a Terminating namespace; delete the Stack's
+	// namespace separately or destroy can deadlock and orphan resources. See the troubleshooting guide for recovery.
 	DestroyOnFinalize bool `json:"destroyOnFinalize,omitempty"`
 	// (optional) RunProgram runs the program during destroy operations (when destroyOnFinalize is set).
 	// This is useful when the program performs setup (e.g., network access, credentials)

--- a/operator/api/pulumi/v1/stack_types.go
+++ b/operator/api/pulumi/v1/stack_types.go
@@ -103,6 +103,9 @@ const (
 	StalledWorkspaceFailedReason = "WorkspaceFailed"
 	// Stalled because the update has failed repeatedly; the operator keeps retrying with backoff
 	StalledUpdateFailedReason = "UpdateFailed"
+	// Stalled because the Stack's namespace is terminating, so a workspace cannot be
+	// created to run destroy. Resources must be cleaned up manually.
+	StalledNamespaceTerminatingReason = "NamespaceTerminating"
 
 	// Ready because processing has completed
 	ReadyCompletedReason = "ProcessingCompleted"

--- a/operator/config/crd/bases/pulumi.com_stacks.yaml
+++ b/operator/config/crd/bases/pulumi.com_stacks.yaml
@@ -139,8 +139,10 @@ spec:
                   When enabled, the resync frequency is controlled by ResyncFrequencySeconds (default 60s).
                 type: boolean
               destroyOnFinalize:
-                description: (optional) DestroyOnFinalize can be set to true to destroy
-                  the stack completely upon deletion of the Stack custom resource.
+                description: |-
+                  (optional) DestroyOnFinalize can be set to true to destroy the stack completely upon deletion of the Stack custom resource.
+                  NOTE: destroy runs in a workspace pod, which cannot be created in a Terminating namespace; delete the Stack's
+                  namespace separately or destroy can deadlock and orphan resources. See the troubleshooting guide for recovery.
                 type: boolean
               envRefs:
                 additionalProperties:
@@ -10748,8 +10750,10 @@ spec:
                   When enabled, the resync frequency is controlled by ResyncFrequencySeconds (default 60s).
                 type: boolean
               destroyOnFinalize:
-                description: (optional) DestroyOnFinalize can be set to true to destroy
-                  the stack completely upon deletion of the Stack custom resource.
+                description: |-
+                  (optional) DestroyOnFinalize can be set to true to destroy the stack completely upon deletion of the Stack custom resource.
+                  NOTE: destroy runs in a workspace pod, which cannot be created in a Terminating namespace; delete the Stack's
+                  namespace separately or destroy can deadlock and orphan resources. See the troubleshooting guide for recovery.
                 type: boolean
               envRefs:
                 additionalProperties:

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -967,6 +967,25 @@ func (r *StackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 	}
 
 	if err := sess.CreateWorkspace(ctx); err != nil {
+		// A workspace can't be created in a deleting namespace, so destroy can't run.
+		// Surface a Stalled condition and keep the finalizer rather than silently orphaning
+		// resources. (An Event can't be emitted here: it too is a namespaced object the API
+		// server rejects in a terminating namespace, so the condition is the only signal that
+		// reaches the user.)
+		if isStackMarkedToBeDeleted && apierrors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
+			detail := "the Pulumi backend"
+			if instance.Status.LastUpdate != nil && instance.Status.LastUpdate.Permalink != "" {
+				detail = string(instance.Status.LastUpdate.Permalink)
+			}
+			msg := fmt.Sprintf("namespace %q is terminating, so a workspace cannot be created to run "+
+				"destroy; cloud resources will NOT be deleted and must be cleaned up manually (see %s). "+
+				"The finalizer is retained to avoid silently orphaning resources. Once the resources are "+
+				"handled, release the Stack with: kubectl patch stack %s -n %s --type=merge "+
+				`-p '{"metadata":{"finalizers":[]}}'`,
+				instance.Namespace, detail, instance.Name, instance.Namespace)
+			instance.Status.MarkStalledCondition(pulumiv1.StalledNamespaceTerminatingReason, msg)
+			return reconcile.Result{RequeueAfter: sourceUnavailableRequeueWait}, saveStatus()
+		}
 		log.Error(err, "cannot create workspace")
 		return reconcile.Result{}, fmt.Errorf("unable to create workspace: %w", err)
 	}

--- a/operator/internal/controller/pulumi/stack_controller_test.go
+++ b/operator/internal/controller/pulumi/stack_controller_test.go
@@ -3056,6 +3056,107 @@ func TestFailedDestroyRetainsFinalizer(t *testing.T) {
 	assert.Contains(t, updated.Finalizers, PulumiFinalizer)
 }
 
+func TestStackDestroyStalledWhenNamespaceTerminating(t *testing.T) {
+	testScheme := scheme.Scheme
+	require.NoError(t, pulumiv1.AddToScheme(testScheme))
+	require.NoError(t, autov1alpha1.AddToScheme(testScheme))
+
+	env := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "config", "crd", "bases"),
+		},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s",
+			fmt.Sprintf("1.28.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
+	}
+	cfg, err := env.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.Stop() })
+
+	k8sclient, err := client.New(cfg, client.Options{Scheme: testScheme})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	nsName := "terminating-ns"
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+	require.NoError(t, k8sclient.Create(ctx, ns))
+
+	stackName := types.NamespacedName{Name: "stalled-destroy", Namespace: nsName}
+
+	// A Program with a ready artifact so the destroy path resolves its source successfully.
+	program := &pulumiv1.Program{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      stackName.Name + "-program",
+			Namespace: nsName,
+		},
+		Program: pulumiv1.ProgramSpec{
+			Resources: map[string]pulumiv1.Resource{
+				"password": {Type: "random:RandomPassword"},
+			},
+		},
+	}
+	require.NoError(t, k8sclient.Create(ctx, program))
+	program.Status.Artifact = &pulumiv1.Artifact{
+		Revision:       "test-revision",
+		LastUpdateTime: metav1.Now(),
+	}
+	program.Status.ObservedGeneration = program.Generation
+	require.NoError(t, k8sclient.Status().Update(ctx, program))
+
+	// A Stack with destroyOnFinalize, mid-deletion and held by the Pulumi finalizer.
+	stack := &pulumiv1.Stack{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: pulumiv1.GroupVersion.String(),
+			Kind:       "Stack",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       stackName.Name,
+			Namespace:  nsName,
+			Finalizers: []string{PulumiFinalizer},
+		},
+		Spec: shared.StackSpec{
+			Stack:             "dev",
+			DestroyOnFinalize: true,
+			ProgramRef:        &shared.ProgramReference{Name: program.Name},
+		},
+	}
+	require.NoError(t, k8sclient.Create(ctx, stack))
+	require.NoError(t, k8sclient.Delete(ctx, stack))
+
+	// envtest has no namespace controller, so a deleted namespace stays Terminating
+	// indefinitely — exactly the state that blocks workspace creation.
+	require.NoError(t, k8sclient.Delete(ctx, ns))
+	require.Eventually(t, func() bool {
+		var got corev1.Namespace
+		if err := k8sclient.Get(ctx, types.NamespacedName{Name: nsName}, &got); err != nil {
+			return false
+		}
+		return got.Status.Phase == corev1.NamespaceTerminating
+	}, 10*time.Second, 100*time.Millisecond, "namespace should be Terminating")
+
+	recorder := record.NewFakeRecorder(10)
+	r := &StackReconciler{
+		Client:   k8sclient,
+		Scheme:   testScheme,
+		Recorder: recorder,
+	}
+	_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: stackName})
+	require.NoError(t, err)
+
+	var updated pulumiv1.Stack
+	require.NoError(t, k8sclient.Get(ctx, stackName, &updated))
+
+	stalledCond := meta.FindStatusCondition(updated.Status.Conditions, pulumiv1.StalledCondition)
+	require.NotNil(t, stalledCond, "expected Stalled condition on Stack")
+	assert.Equal(t, metav1.ConditionTrue, stalledCond.Status)
+	assert.Equal(t, pulumiv1.StalledNamespaceTerminatingReason, stalledCond.Reason)
+	assert.Contains(t, stalledCond.Message, "terminating")
+	assert.Contains(t, stalledCond.Message, "kubectl patch", "message should tell the user how to release the Stack")
+
+	assert.Contains(t, updated.Finalizers, PulumiFinalizer, "finalizer must be retained so resources are not silently orphaned")
+}
+
 // TestStackStatusConcurrentModification proves that the Stack controller's
 // SSA-based status writes succeed even when another client concurrently modifies
 // metadata (e.g. sets a label), which bumps the object's resourceVersion. The


### PR DESCRIPTION
This pull request adds a troubleshooting messagewhen a Stack with DestroyOnFinalize is hung due to being in a terminating Namespace.

Workspace pods need to be newly created for each pulumi operation, but when a Kubernetes Namespace is in Terminating state, no new object creations are possible.
Best practice says to manually order a Namespace object to be deleted _after_ its CRDs, but we can help out the user by logging a warning and troubleshooting steps.

Addresses #1181.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
