### PR TITLE
Retain finalizer and retry when destroyOnFinalize destroy fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## Unreleased
 
 - Fix `destroyOnFinalize: true` silently skipping `pulumi destroy` for any Stack that had been successfully reconciled [#1223](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1223)
+- Fix `destroyOnFinalize: true` removing the finalizer and silently orphaning a Stack's cloud resources when `pulumi destroy` fails; the operator now retains the finalizer and retries the destroy with backoff instead of deleting the Stack [#1233](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1233)
 - Fix `destroyOnFinalize: true` getting stuck in `Stalled / SourceUnavailable` when a Stack is deleted together with its source (an inline `Program` or a Flux source); the operator now destroys from backend state without re-fetching the source [#1222](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1222) [#441](https://github.com/pulumi/pulumi-kubernetes-operator/issues/441)
 
 ## 2.7.0 (2026-04-06)

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -812,6 +812,15 @@ func (r *StackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 		}
 
 		if isStackMarkedToBeDeleted {
+			// Only finalize if the destroy succeeded; a failed destroy must retain the
+			// finalizer and retry, not silently orphan the stack's resources.
+			if instance.Status.LastUpdate.State != shared.SucceededStackStateMessage {
+				log.Info("Destroy failed; retaining finalizer and retrying after backoff",
+					"failures", instance.Status.LastUpdate.Failures, "message", instance.Status.LastUpdate.Message)
+				requeueAfter := max(1*time.Second, time.Until(instance.Status.LastUpdate.LastResyncTime.Add(cooldown(instance))))
+				return reconcile.Result{RequeueAfter: requeueAfter}, saveStatus()
+			}
+
 			log.Info("Stack was destroyed; finalizing now.")
 			_ = saveStatus()
 			if controllerutil.RemoveFinalizer(instance, PulumiFinalizer) {

--- a/operator/internal/controller/pulumi/stack_controller_test.go
+++ b/operator/internal/controller/pulumi/stack_controller_test.go
@@ -2992,6 +2992,74 @@ func TestProjectInfoDestroyBypassesUnavailableSource(t *testing.T) {
 	assert.Equal(t, autov1alpha1.DestroyType, update.Spec.Type, "Update CR must be of type destroy")
 }
 
+func TestFailedDestroyRetainsFinalizer(t *testing.T) {
+	testScheme := scheme.Scheme
+	require.NoError(t, pulumiv1.AddToScheme(testScheme))
+	require.NoError(t, autov1alpha1.AddToScheme(testScheme))
+
+	env := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "config", "crd", "bases"),
+		},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s",
+			fmt.Sprintf("1.28.3-%s-%s", runtime.GOOS, runtime.GOARCH)),
+	}
+	cfg, err := env.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.Stop() })
+
+	k8sclient, err := client.New(cfg, client.Options{Scheme: testScheme})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	stackName := types.NamespacedName{Name: "failed-destroy", Namespace: "default"}
+
+	stack := &pulumiv1.Stack{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: pulumiv1.GroupVersion.String(),
+			Kind:       "Stack",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       stackName.Name,
+			Namespace:  stackName.Namespace,
+			Finalizers: []string{testFinalizer, PulumiFinalizer},
+		},
+		Spec: shared.StackSpec{Stack: "dev", DestroyOnFinalize: true},
+	}
+	require.NoError(t, k8sclient.Create(ctx, stack))
+	t.Cleanup(func() { _ = k8sclient.Delete(ctx, stack) })
+
+	// Mark for deletion, then record a destroy that just FAILED (still within its backoff
+	// cooldown). ProjectInfo makes the destroy take the source-less bypass (currentCommit == "");
+	// seeding the status after the delete keeps LastUpdate.Generation aligned with the
+	// post-delete generation. Together these make isSynced return true on the failed-update
+	// path — exactly where the old code removed the finalizer.
+	require.NoError(t, k8sclient.Delete(ctx, stack))
+	require.NoError(t, k8sclient.Get(ctx, stackName, stack))
+	stack.Status.ProjectInfo = &shared.ProjectInfo{Name: "myproject", Runtime: "yaml"}
+	stack.Status.LastUpdate = &shared.StackUpdateState{
+		Generation:     stack.Generation,
+		Name:           "destroy-failed",
+		Type:           autov1alpha1.DestroyType,
+		State:          shared.FailedStackStateMessage,
+		Message:        "destroy failed: BucketNotEmpty",
+		LastResyncTime: metav1.Now(),
+		Failures:       1,
+	}
+	require.NoError(t, k8sclient.Status().Update(ctx, stack))
+
+	r := &StackReconciler{Client: k8sclient, Scheme: testScheme, Recorder: record.NewFakeRecorder(10)}
+	_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: stackName})
+	require.NoError(t, err)
+
+	// A failed destroy must not delete the Stack and orphan its resources. testFinalizer keeps
+	// the object queryable, so the assertion isolates PulumiFinalizer.
+	var updated pulumiv1.Stack
+	require.NoError(t, k8sclient.Get(ctx, stackName, &updated))
+	assert.Contains(t, updated.Finalizers, PulumiFinalizer)
+}
+
 // TestStackStatusConcurrentModification proves that the Stack controller's
 // SSA-based status writes succeed even when another client concurrently modifies
 // metadata (e.g. sets a label), which bumps the object's resourceVersion. The


### PR DESCRIPTION
When a `destroyOnFinalize: true` Stack's `pulumi destroy` fails, the operator currently removes the Pulumi finalizer on the same reconcile that observes the failure — deleting the Stack and silently orphaning its cloud resources after a single failed attempt (the log even claims "Stack was destroyed"). This happens because `isSynced` returns true during the post-failure cooldown, and the finalize branch removed the finalizer without checking whether the destroy actually succeeded.

This guards finalizer removal on `LastUpdate.State == Succeeded`. A failed destroy now retains the finalizer and retries with the existing exponential backoff, exactly like a failed update — surfaced via `Reconciling / RetryingAfterFailure` and the Update's error, never silently abandoned. The deliberate escape hatch remains a manual `kubectl patch stack … finalizers:[]`.

Closes #1233.

## Test plan

- `TestFailedDestroyRetainsFinalizer` (envtest): seeds a failed destroy in its backoff cooldown, reconciles, and asserts the Pulumi finalizer is retained. Verified it **fails against `origin/master`** (finalizer stripped → orphan) and **passes with this change**.
- Full `internal/controller/pulumi` package green via `KUBEBUILDER_ASSETS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)