### PR TITLE
helm: make controller liveness/readiness probes configurable

### DIFF
--- a/deploy/helm/pulumi-operator/templates/deployment.yaml
+++ b/deploy/helm/pulumi-operator/templates/deployment.yaml
@@ -99,14 +99,18 @@ spec:
           httpGet:
             path: /healthz
             port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         readinessProbe:
           httpGet:
             path: /readyz
             port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/pulumi-operator/values.yaml
+++ b/deploy/helm/pulumi-operator/values.yaml
@@ -50,6 +50,26 @@ kubeAPI:
   # Increase this value if experiencing kube-apiserver slowness that causes leader election failures
   timeout: "30s"
 
+# Liveness probe for the controller manager (/healthz on :8081)
+# Increase timeoutSeconds/failureThreshold if long-running Pulumi operations can briefly
+# starve the manager's health endpoint and cause spurious restarts.
+livenessProbe:
+  initialDelaySeconds: 15
+  periodSeconds: 20
+  # -- Seconds before the probe times out (Kubernetes default is 1, which is aggressive under load)
+  timeoutSeconds: 1
+  # -- Consecutive failures before the container is restarted
+  failureThreshold: 3
+
+# Readiness probe for the controller manager (/readyz on :8081)
+readinessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  # -- Seconds before the probe times out (Kubernetes default is 1, which is aggressive under load)
+  timeoutSeconds: 1
+  # -- Consecutive failures before the pod is marked NotReady
+  failureThreshold: 3
+
 # -- Extra Environments to be passed to the operator
 extraEnv: []
 


### PR DESCRIPTION
## Summary

Fixes #1254.

The controller-manager `Deployment` hardcodes its liveness and readiness probes and never sets `timeoutSeconds`/`failureThreshold`, so they fall back to the Kubernetes default of `timeoutSeconds: 1`. When the manager is busy during long-running Pulumi operations, `/healthz` can fail to answer within 1s; after the default 3 consecutive failures the kubelet SIGTERMs the container (exit 143) and cancels the in-flight update mid-run.

This mirrors the long-running-operation concern already addressed for leader election in #1059, but the probe timeouts were left at the aggressive Kubernetes defaults.

## Changes

- Expose `livenessProbe` and `readinessProbe` (`initialDelaySeconds`, `periodSeconds`, `timeoutSeconds`, `failureThreshold`) in `values.yaml`.
- Wire them into `templates/deployment.yaml`.

## Backwards compatibility

Defaults are preserved (`timeoutSeconds: 1`, `failureThreshold: 3`), so there is **no behavior change** for existing users. Operators running long Pulumi operations can opt into more tolerant values, e.g.:

```yaml
livenessProbe:
  timeoutSeconds: 5
  failureThreshold: 5
readinessProbe:
  timeoutSeconds: 5
  failureThreshold: 5
```

## Testing

`helm template` renders the current defaults unchanged, and honors overrides:

- defaults → `timeoutSeconds: 1`, `failureThreshold: 3`
- `--set livenessProbe.timeoutSeconds=5 --set livenessProbe.failureThreshold=5` → `timeoutSeconds: 5`, `failureThreshold: 5`