### PR TITLE
Introduce Maximum Retries and related failure modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 - Fix `destroyOnFinalize: true` silently skipping `pulumi destroy` for any Stack that had been successfully reconciled [#1223](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1223)
 - Fix `destroyOnFinalize: true` getting stuck in `Stalled / SourceUnavailable` when a Stack is deleted together with its source (an inline `Program` or a Flux source); the operator now destroys from backend state without re-fetching the source [#1222](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1222) [#441](https://github.com/pulumi/pulumi-kubernetes-operator/issues/441)
 - Re-generate shipped CRDs and docs to match `config/crd/bases`, and add a CI gate that fails on codegen drift [#1252](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1252)
+- Bound update retries: after repeated failures a Stack is marked `Stalled` and stops retrying until its spec or source changes [#1007](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1007)
 
 ## 2.7.0 (2026-04-06)
 

--- a/operator/api/pulumi/v1/stack_types.go
+++ b/operator/api/pulumi/v1/stack_types.go
@@ -86,6 +86,8 @@ const (
 	ReconcilingProcessingUpdateMessage    = "stack is being processed"
 	// Reconciling because it failed, and has been requeued
 	ReconcilingRetryReason = "RetryingAfterFailure"
+	// Reconciling because a preview failed; the proposed update would not apply
+	ReconcilingPreviewFailedReason = "PreviewFailed"
 	// Reconciling because a prerequisite was not satisfied
 	ReconcilingPrerequisiteNotSatisfiedReason = "PrerequisiteNotSatisfied"
 
@@ -99,6 +101,8 @@ const (
 	StalledPulumiVersionTooLowReason = "PulumiVersionTooLow"
 	// Stalled because the workspace failed to initialize or install dependencies.
 	StalledWorkspaceFailedReason = "WorkspaceFailed"
+	// Stalled because the update has failed repeatedly; the operator keeps retrying with backoff
+	StalledUpdateFailedReason = "UpdateFailed"
 
 	// Ready because processing has completed
 	ReadyCompletedReason = "ProcessingCompleted"

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -805,11 +805,7 @@ func (r *StackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 	if synced {
 		// We don't mark the stack as ready if its update failed so downstream
 		// Stack dependencies aren't triggered.
-		if instance.Status.LastUpdate.State == shared.SucceededStackStateMessage {
-			instance.Status.MarkReadyCondition()
-		} else {
-			instance.Status.MarkReconcilingCondition(pulumiv1.ReconcilingRetryReason, fmt.Sprintf("%d update failure(s)", instance.Status.LastUpdate.Failures))
-		}
+		markStackResult(&instance.Status)
 
 		if isStackMarkedToBeDeleted {
 			log.Info("Stack was destroyed; finalizing now.")
@@ -825,10 +821,13 @@ func (r *StackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 		requeueAfter := time.Duration(0)
 		updateFailed := false
 
-		// Try again with exponential backoff if the update failed.
+		// Try again with exponential backoff if the update failed, until the retry
+		// limit is reached.
 		if instance.Status.LastUpdate.State == shared.FailedStackStateMessage {
 			updateFailed = true
-			requeueAfter = max(1*time.Second, time.Until(instance.Status.LastUpdate.LastResyncTime.Add(cooldown(instance))))
+			if instance.Status.LastUpdate.Failures < maxUpdateFailures {
+				requeueAfter = max(1*time.Second, time.Until(instance.Status.LastUpdate.LastResyncTime.Add(cooldown(instance))))
+			}
 		}
 		// Schedule another poll if ContinueResyncOnCommitMatch is set, for drift detection or to maintain dynamic resources.
 		if instance.Status.LastUpdate.State == shared.SucceededStackStateMessage && sess.stack.ContinueResyncOnCommitMatch {
@@ -1049,6 +1048,39 @@ func (r *StackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 	return reconcile.Result{}, nil
 }
 
+// maxUpdateFailures bounds how many times a failing update is retried before the
+// operator gives up. Below the limit a failure is treated as transient: the Stack stays
+// Reconciling and retries with backoff.
+//
+// TODO: promote to a spec field.
+const maxUpdateFailures = 3
+
+// markStackResult sets the ready-protocol condition from the outcome of the last update.
+// A failed preview is reported distinctly from a failed up/refresh/destroy so consumers
+// (e.g. ArgoCD health checks) can tell a bad proposed change apart from a failed live update.
+func markStackResult(status *pulumiv1.StackStatus) {
+	last := status.LastUpdate
+	if last.State == shared.SucceededStackStateMessage {
+		status.MarkReadyCondition()
+		return
+	}
+	// The update failed. Once the retry limit is reached we stop retrying, so this
+	// Stalled takes precedence over the per-type reasons below regardless of update type.
+	if last.Failures >= maxUpdateFailures {
+		status.MarkStalledCondition(pulumiv1.StalledUpdateFailedReason,
+			fmt.Sprintf("%s failed %d times; not retrying until the spec or source changes", last.Type, last.Failures))
+		return
+	}
+	// Still within the retry budget: surface a failed preview distinctly from a failed live update.
+	if last.Type == autov1alpha1.PreviewType {
+		status.MarkReconcilingCondition(pulumiv1.ReconcilingPreviewFailedReason,
+			fmt.Sprintf("preview failed (%d attempt(s))", last.Failures))
+		return
+	}
+	status.MarkReconcilingCondition(pulumiv1.ReconcilingRetryReason,
+		fmt.Sprintf("%d update failure(s)", last.Failures))
+}
+
 // markStackFailed updates the status of the Stack object `instance` locally, to reflect a failure to process the stack.
 func (r *StackReconciler) markStackFailed(sess *stackReconcilerSession, instance *pulumiv1.Stack, current *shared.CurrentStackUpdate, update *autov1alpha1.Update) {
 	sess.logger.Info("Failed to update Stack", "Stack.Name", sess.stack.Stack, "Message", update.Status.Message)
@@ -1220,6 +1252,12 @@ func isSynced(log logr.Logger, recorder record.EventRecorder, stack *pulumiv1.St
 			msg := fmt.Sprintf("New commit detected: %q", currentCommit)
 			emitEvent(recorder, stack, pulumiv1.StackUpdateDetectedEvent(), msg)
 			return false, msg
+		}
+		if stack.Status.LastUpdate.Failures >= maxUpdateFailures {
+			// Retry limit reached with unchanged inputs; stop retrying.
+			log.V(1).Info("Synced: update retry limit reached; not retrying until inputs change",
+				"failures", stack.Status.LastUpdate.Failures)
+			return true, ""
 		}
 		c := cooldown(stack)
 		if time.Since(stack.Status.LastUpdate.LastResyncTime.Time) >= c {

--- a/operator/internal/controller/pulumi/stack_controller_test.go
+++ b/operator/internal/controller/pulumi/stack_controller_test.go
@@ -891,7 +891,7 @@ var _ = Describe("Stack Controller", func() {
 					LastResyncTime:       metav1.Now(),
 					LastAttemptedCommit:  fluxRepo.Status.Artifact.Revision,
 					LastSuccessfulCommit: "",
-					Failures:             3,
+					Failures:             maxUpdateFailures - 1, // one below the limit: still retrying
 				}
 			})
 
@@ -899,9 +899,9 @@ var _ = Describe("Stack Controller", func() {
 				It("backs off exponentially", func(ctx context.Context) {
 					res, err := reconcileF(ctx)
 					Expect(err).NotTo(HaveOccurred())
-					// 10 seconds * 3^3 = 4m30s
-					Expect(res.RequeueAfter).To(BeNumerically("~", 4*time.Minute, time.Minute))
-					ByMarkingAsReconciling(pulumiv1.ReconcilingRetryReason, Equal("3 update failure(s)"))
+					// 10 seconds * 3^2 = 1m30s
+					Expect(res.RequeueAfter).To(BeNumerically("~", 90*time.Second, 30*time.Second))
+					ByMarkingAsReconciling(pulumiv1.ReconcilingRetryReason, Equal("2 update failure(s)"))
 				})
 
 				When("the WorkspaceReclaimPolicy is set to Delete", func() {
@@ -928,32 +928,28 @@ var _ = Describe("Stack Controller", func() {
 			})
 		})
 
-		When("the last update was not successful and max retry cooldown is set", func() {
+		When("the update has failed past the retry limit", func() {
 			BeforeEach(func(ctx context.Context) {
 				obj.Status.LastUpdate = &shared.StackUpdateState{
 					Generation:           1,
 					State:                shared.FailedStackStateMessage,
 					Name:                 "update-abcdef",
 					Type:                 autov1alpha1.UpType,
-					LastResyncTime:       metav1.Now(),
+					LastResyncTime:       metav1.NewTime(time.Now().Add(-1 * time.Hour)), // cooldown long elapsed
 					LastAttemptedCommit:  fluxRepo.Status.Artifact.Revision,
 					LastSuccessfulCommit: "",
-					Failures:             10,
+					Failures:             10, // past maxUpdateFailures
 				}
-				// Set a custom max backoff duration (e.g., 5 minutes)
-				obj.Spec.RetryMaxBackoffDurationSeconds = int64(300)
 			})
-			When("done cooling down with the custom duration", func() {
-				It("backs off according to the max backoff", func(ctx context.Context) {
-					res, err := reconcileF(ctx)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(res.RequeueAfter).To(BeNumerically("~", 5*time.Minute, time.Minute))
-				})
-				It("reconciles", func(ctx context.Context) {
-					_, err := reconcileF(ctx)
-					Expect(err).NotTo(HaveOccurred())
-					ByMarkingAsReconciling(pulumiv1.ReconcilingRetryReason, Equal("10 update failure(s)"))
-				})
+			It("stops retrying - no backoff requeue", func(ctx context.Context) {
+				res, err := reconcileF(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res.RequeueAfter).To(BeZero())
+			})
+			It("marks the stack as stalled", func(ctx context.Context) {
+				_, err := reconcileF(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				ByMarkingAsStalled(pulumiv1.StalledUpdateFailedReason, Equal("up failed 10 times; not retrying until the spec or source changes"))
 			})
 		})
 

--- a/operator/internal/controller/pulumi/stack_result_test.go
+++ b/operator/internal/controller/pulumi/stack_result_test.go
@@ -1,0 +1,97 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulumi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	autov1alpha1 "github.com/pulumi/pulumi-kubernetes-operator/v2/operator/api/auto/v1alpha1"
+	"github.com/pulumi/pulumi-kubernetes-operator/v2/operator/api/pulumi/shared"
+	pulumiv1 "github.com/pulumi/pulumi-kubernetes-operator/v2/operator/api/pulumi/v1"
+)
+
+func TestMarkStackResult(t *testing.T) {
+	tests := []struct {
+		name       string
+		lastUpdate shared.StackUpdateState
+		wantReady  metav1.ConditionStatus
+		wantCond   string // condition expected to carry the distinguishing reason
+		wantReason string
+	}{
+		{
+			name:       "successful up is Ready",
+			lastUpdate: shared.StackUpdateState{Type: autov1alpha1.UpType, State: shared.SucceededStackStateMessage},
+			wantReady:  metav1.ConditionTrue,
+			wantCond:   pulumiv1.ReadyCondition,
+			wantReason: pulumiv1.ReadyCompletedReason,
+		},
+		{
+			name:       "successful preview is Ready",
+			lastUpdate: shared.StackUpdateState{Type: autov1alpha1.PreviewType, State: shared.SucceededStackStateMessage},
+			wantReady:  metav1.ConditionTrue,
+			wantCond:   pulumiv1.ReadyCondition,
+			wantReason: pulumiv1.ReadyCompletedReason,
+		},
+		{
+			name:       "transient up failure stays Reconciling",
+			lastUpdate: shared.StackUpdateState{Type: autov1alpha1.UpType, State: shared.FailedStackStateMessage, Failures: maxUpdateFailures - 1},
+			wantReady:  metav1.ConditionFalse,
+			wantCond:   pulumiv1.ReconcilingCondition,
+			wantReason: pulumiv1.ReconcilingRetryReason,
+		},
+		{
+			name:       "transient preview failure is reported distinctly",
+			lastUpdate: shared.StackUpdateState{Type: autov1alpha1.PreviewType, State: shared.FailedStackStateMessage, Failures: 1},
+			wantReady:  metav1.ConditionFalse,
+			wantCond:   pulumiv1.ReconcilingCondition,
+			wantReason: pulumiv1.ReconcilingPreviewFailedReason,
+		},
+		{
+			name:       "persistent up failure stalls",
+			lastUpdate: shared.StackUpdateState{Type: autov1alpha1.UpType, State: shared.FailedStackStateMessage, Failures: maxUpdateFailures},
+			wantReady:  metav1.ConditionFalse,
+			wantCond:   pulumiv1.StalledCondition,
+			wantReason: pulumiv1.StalledUpdateFailedReason,
+		},
+		{
+			name:       "persistent preview failure stalls",
+			lastUpdate: shared.StackUpdateState{Type: autov1alpha1.PreviewType, State: shared.FailedStackStateMessage, Failures: maxUpdateFailures + 5},
+			wantReady:  metav1.ConditionFalse,
+			wantCond:   pulumiv1.StalledCondition,
+			wantReason: pulumiv1.StalledUpdateFailedReason,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status := &pulumiv1.StackStatus{LastUpdate: &tt.lastUpdate}
+			markStackResult(status)
+
+			ready := apimeta.FindStatusCondition(status.Conditions, pulumiv1.ReadyCondition)
+			if assert.NotNil(t, ready, "Ready condition must be set") {
+				assert.Equal(t, tt.wantReady, ready.Status)
+			}
+
+			cond := apimeta.FindStatusCondition(status.Conditions, tt.wantCond)
+			if assert.NotNil(t, cond, "expected %s condition to be set", tt.wantCond) {
+				assert.Equal(t, tt.wantReason, cond.Reason)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently, when a `pulumi up` fails inside the Workspace, the Operator continues to try to reconcile the operation, continuously kicking off new Update CRs at larger and larger backoff periods. The Stack Status reads `Reconciling=True/RetryingAfterFailure`, forever. 

But most of the time, when a pulumi up fails, the failure is deterministic and repeated. A new `pulumi up` will most of the time not somehow succeed where it failed before.

When you hook up the Operator to ArgoCD or any kind of health check, the health check will show a Progressing stack, which is misleading in the case of repeated `pulumi up` failures.

This pull request adds a hardcoded (for now) maximum update failure const of 3. If `pulumi up` fails to succeed 3 times in a row, the Stack Status flips from Progressing to Stalled. Integrations will now show a closer version of the truth. To aid with surfacing the correct failure reasons, `ReconcilingPreviewFailedReason` and `StalledUpdateFailedReason` were added.

This work satisfies the code/logic parts of https://github.com/pulumi/pulumi-kubernetes-operator/issues/1007. With this logic in place, a standard Lua health check will report the reality of "your pulumi up failed" pretty consistently on ArgoCD. Other tooling should benefit as well (although I've only tried this with Argo + Lua). 


