### PR TITLE
Make Flux source artifact size limit configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## Unreleased
 
+- Make the Flux source artifact extraction size limit configurable via the `flux.maxUntarSizeBytes` Helm value (`FLUX_MAX_UNTAR_SIZE_BYTES`), overriding the built-in 100 MiB cap [#1261](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1261)
 - Fix `destroyOnFinalize: true` silently skipping `pulumi destroy` for any Stack that had been successfully reconciled [#1223](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1223)
 - Fix `destroyOnFinalize: true` removing the finalizer and silently orphaning a Stack's cloud resources when `pulumi destroy` fails; the operator now retains the finalizer and retries the destroy with backoff instead of deleting the Stack [#1233](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1233)
 - Fix `destroyOnFinalize: true` getting stuck in `Stalled / SourceUnavailable` when a Stack is deleted together with its source (an inline `Program` or a Flux source); the operator now destroys from backend state without re-fetching the source [#1222](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1222) [#441](https://github.com/pulumi/pulumi-kubernetes-operator/issues/441)

--- a/agent/cmd/init.go
+++ b/agent/cmd/init.go
@@ -21,9 +21,11 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/blang/semver"
 	"github.com/fluxcd/pkg/http/fetch"
+	"github.com/fluxcd/pkg/tar"
 	git "github.com/go-git/go-git/v5"
 	"github.com/pulumi/pulumi-kubernetes-operator/v2/agent/pkg/gitauth"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
@@ -71,14 +73,11 @@ For Flux sources:
 		}
 		// https://github.com/fluxcd/kustomize-controller/blob/a1a33f2adda783dd2a17234f5d8e84caca4e24e2/internal/controller/kustomization_controller.go#L328
 		if _fluxURL != "" {
-			f = &fluxFetcher{
-				url:    _fluxURL,
-				digest: _fluxDigest,
-				wrapped: fetch.New(
-					fetch.WithRetries(3),
-					fetch.WithHostnameOverwrite(os.Getenv("SOURCE_CONTROLLER_LOCALHOST")),
-					fetch.WithUntar()),
+			ff, err := newFluxFetcher(_fluxURL, _fluxDigest)
+			if err != nil {
+				return err
 			}
+			f = ff
 		}
 		return runInit(ctx, log, _targetDir, f, g)
 	},
@@ -168,6 +167,38 @@ func writeProjectFile(targetDir, name, runtime string) error {
 		return fmt.Errorf("writing project-info Pulumi.yaml: %w", err)
 	}
 	return nil
+}
+
+// newFluxFetcher builds a fluxFetcher for the given artifact, applying the
+// configured untar size limit (see fluxUntarOptions).
+func newFluxFetcher(url, digest string) (*fluxFetcher, error) {
+	untarOpts, err := fluxUntarOptions()
+	if err != nil {
+		return nil, err
+	}
+	return &fluxFetcher{
+		url:    url,
+		digest: digest,
+		wrapped: fetch.New(
+			fetch.WithRetries(3),
+			fetch.WithHostnameOverwrite(os.Getenv("SOURCE_CONTROLLER_LOCALHOST")),
+			fetch.WithUntar(untarOpts...)),
+	}, nil
+}
+
+// fluxUntarOptions derives the tar options for extracting a Flux artifact. The
+// FLUX_MAX_UNTAR_SIZE_BYTES environment variable overrides fluxcd/pkg/tar's
+// default 100 MiB cap; a value of -1 disables the limit entirely.
+func fluxUntarOptions() ([]tar.TarOption, error) {
+	v := os.Getenv("FLUX_MAX_UNTAR_SIZE_BYTES")
+	if v == "" {
+		return nil, nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return nil, fmt.Errorf("invalid FLUX_MAX_UNTAR_SIZE_BYTES %q: %w", v, err)
+	}
+	return []tar.TarOption{tar.WithMaxUntarSize(n)}, nil
 }
 
 type fetchWithContexter interface {

--- a/agent/cmd/init_test.go
+++ b/agent/cmd/init_test.go
@@ -15,6 +15,13 @@
 package cmd
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,6 +29,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 )
@@ -42,6 +50,78 @@ func TestInitFluxSource(t *testing.T) {
 
 	err := runInit(t.Context(), log, dir, f, nil)
 	assert.NoError(t, err)
+}
+
+func TestFluxUntarOptions(t *testing.T) {
+	t.Run("unset does not override the default", func(t *testing.T) {
+		t.Setenv("FLUX_MAX_UNTAR_SIZE_BYTES", "")
+		opts, err := fluxUntarOptions()
+		assert.NoError(t, err)
+		assert.Nil(t, opts)
+	})
+
+	t.Run("a valid size is accepted", func(t *testing.T) {
+		t.Setenv("FLUX_MAX_UNTAR_SIZE_BYTES", "524288000")
+		opts, err := fluxUntarOptions()
+		assert.NoError(t, err)
+		assert.NotEmpty(t, opts)
+	})
+
+	t.Run("a non-numeric value errors", func(t *testing.T) {
+		t.Setenv("FLUX_MAX_UNTAR_SIZE_BYTES", "big")
+		_, err := fluxUntarOptions()
+		assert.Error(t, err)
+	})
+}
+
+func TestInitFluxSource_UntarSizeLimit(t *testing.T) {
+	const extractedSize = 2048
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	content := bytes.Repeat([]byte("a"), extractedSize)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "data.txt",
+		Mode:     0o600,
+		Size:     int64(len(content)),
+	}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	archive := buf.Bytes()
+
+	sum := sha256.Sum256(archive)
+	digest := "sha256:" + hex.EncodeToString(sum[:])
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	}))
+	t.Cleanup(srv.Close)
+
+	fetchInto := func(t *testing.T, targetDir string) error {
+		f, err := newFluxFetcher(srv.URL, digest)
+		require.NoError(t, err)
+		return runInit(t.Context(), zap.L().Named(t.Name()).Sugar(), targetDir, f, nil)
+	}
+
+	t.Run("fails when the artifact exceeds the configured limit", func(t *testing.T) {
+		t.Setenv("FLUX_MAX_UNTAR_SIZE_BYTES", "1024")
+		err := fetchInto(t, t.TempDir())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bigger than max archive size")
+	})
+
+	t.Run("succeeds when the limit is raised above the artifact size", func(t *testing.T) {
+		t.Setenv("FLUX_MAX_UNTAR_SIZE_BYTES", "1048576")
+		dir := t.TempDir()
+		require.NoError(t, fetchInto(t, dir))
+		extracted, err := os.ReadFile(filepath.Join(dir, "data.txt"))
+		require.NoError(t, err)
+		assert.Len(t, extracted, extractedSize)
+	})
 }
 
 func TestWriteProjectFile(t *testing.T) {

--- a/deploy/helm/pulumi-operator/templates/deployment.yaml
+++ b/deploy/helm/pulumi-operator/templates/deployment.yaml
@@ -71,6 +71,10 @@ spec:
         - name: KUBE_API_TIMEOUT
           value: {{ .Values.kubeAPI.timeout | quote }}
         {{- end }}
+        {{- if and .Values.flux (ne (toString .Values.flux.maxUntarSizeBytes) "") }}
+        - name: FLUX_MAX_UNTAR_SIZE_BYTES
+          value: {{ .Values.flux.maxUntarSizeBytes | quote }}
+        {{- end }}
         ports:
         - containerPort: 8383
           name: http-metrics

--- a/deploy/helm/pulumi-operator/values.yaml
+++ b/deploy/helm/pulumi-operator/values.yaml
@@ -50,6 +50,12 @@ kubeAPI:
   # Increase this value if experiencing kube-apiserver slowness that causes leader election failures
   timeout: "30s"
 
+# Flux source configuration
+flux:
+  # -- Max size in bytes for extracting a Flux source artifact. Empty uses the
+  # built-in default (100 MiB); set higher for large artifacts, or -1 to disable the limit.
+  maxUntarSizeBytes: ""
+
 # -- Extra Environments to be passed to the operator
 extraEnv: []
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -84,6 +84,18 @@ the pod connects to the `source-controller` pod in the `flux-system` namespace.
 If your cluster has [Network Policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) enabled,
 a policy must be configured to allow the above traffic. Apply this manifest: [operator/config/flux/network_policy.yaml](./operator/config/flux/network_policy.yaml).
 
+#### Flux artifact exceeds the extraction size limit
+
+The `fetch` init container extracts the Flux artifact with a default cap of 100 MiB on the *uncompressed*
+contents. A larger artifact fails init with an error such as `bigger than max archive size`.
+
+Raise the cap by setting the `FLUX_MAX_UNTAR_SIZE_BYTES` environment variable on the operator (bytes; `-1`
+disables the limit):
+
+- **Helm**: set `flux.maxUntarSizeBytes`, e.g. `--set flux.maxUntarSizeBytes=524288000`.
+- **Kustomize / raw manifests**: add the env var to the manager container.
+- **Local (`make run`)**: `export FLUX_MAX_UNTAR_SIZE_BYTES=524288000` before running.
+
 ### Stack Conflicts
 
 On rare occasion, your Pulumi stack may become locked in the state backend. To unlock your stack:

--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fluxcd/pkg/apis/acl v0.3.0 // indirect
 	github.com/fluxcd/pkg/apis/meta v1.5.0 // indirect
-	github.com/fluxcd/pkg/tar v0.7.0 // indirect
+	github.com/fluxcd/pkg/tar v0.7.0
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect

--- a/operator/internal/controller/auto/workspace_controller.go
+++ b/operator/internal/controller/auto/workspace_controller.go
@@ -774,6 +774,12 @@ ln -s "/share/source/$FLUX_DIR" /share/workspace
 			},
 			Args: []string{"sh", "-c", script},
 		}
+		if v := os.Getenv("FLUX_MAX_UNTAR_SIZE_BYTES"); v != "" {
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name:  "FLUX_MAX_UNTAR_SIZE_BYTES",
+				Value: v,
+			})
+		}
 		statefulset.Spec.Template.Spec.InitContainers = append(statefulset.Spec.Template.Spec.InitContainers, container)
 	}
 


### PR DESCRIPTION
This pull request enables the operator to read and apply the `FLUX_MAX_UNTAR_SIZE_BYTES` environment variable.

Implements https://github.com/pulumi/pulumi-kubernetes-operator/issues/1261.

