### PR TITLE
Prepare release v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## Unreleased
 
+## 2.8.0 (2026-07-21)
+
 - Make the Flux source artifact extraction size limit configurable via the `flux.maxUntarSizeBytes` Helm value (`FLUX_MAX_UNTAR_SIZE_BYTES`), overriding the built-in 100 MiB cap [#1261](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1261)
 - Fix `destroyOnFinalize: true` silently skipping `pulumi destroy` for any Stack that had been successfully reconciled [#1223](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1223)
 - Fix `destroyOnFinalize: true` removing the finalizer and silently orphaning a Stack's cloud resources when `pulumi destroy` fails; the operator now retains the finalizer and retries the destroy with backoff instead of deleting the Stack [#1233](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1233)

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ A simple "quickstart" installation manifest is provided for non-production envir
 Install with `kubectl`:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/pulumi/pulumi-kubernetes-operator/refs/tags/v2.7.0/deploy/quickstart/install.yaml
+kubectl apply -f https://raw.githubusercontent.com/pulumi/pulumi-kubernetes-operator/refs/tags/v2.8.0/deploy/quickstart/install.yaml
 ```
 
 ### From Source
 
 To build and install the operator from this repository:
 
-1. Build the operator image: `make build-image` (produces `pulumi/pulumi-kubernetes-operator:v2.7.0`).
+1. Build the operator image: `make build-image` (produces `pulumi/pulumi-kubernetes-operator:v2.8.0`).
 2. Push or load the image into your cluster's registry.
 3. Deploy to your current cluster context: `make deploy`.
 

--- a/agent/version/version.go
+++ b/agent/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-var Version string = "v2.7.0"
+var Version string = "v2.8.0"

--- a/deploy/deploy-operator-yaml/Pulumi.yaml
+++ b/deploy/deploy-operator-yaml/Pulumi.yaml
@@ -5,7 +5,7 @@ description: |
 config:
   version: # The version to install of the Pulumi Kubernetes Operator.
     type: string
-    default: v2.7.0
+    default: v2.8.0
 resources:
   pko:
     type: kubernetes:kustomize/v2:Directory

--- a/deploy/helm/pulumi-operator/Chart.yaml
+++ b/deploy/helm/pulumi-operator/Chart.yaml
@@ -9,8 +9,8 @@ icon: https://www.pulumi.com/logos/brand/avatar-on-white.svg
 
 type: application
 
-version: "2.7.0"
-appVersion: "v2.7.0"
+version: "2.8.0"
+appVersion: "v2.8.0"
 
 keywords:
   - pulumi
@@ -32,7 +32,7 @@ annotations:
     - New operator version
   artifacthub.io/images: |
     - name: pulumi-kubernetes-operator
-      image: docker.io/pulumi/pulumi-kubernetes-operator:v2.7.0
+      image: docker.io/pulumi/pulumi-kubernetes-operator:v2.8.0
       platforms:
         - linux/amd64
         - linux/arm64

--- a/deploy/helm/pulumi-operator/README.md
+++ b/deploy/helm/pulumi-operator/README.md
@@ -1,6 +1,6 @@
 # Pulumi Kubernetes Operator - Helm Chart
 
-![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: v2.7.0](https://img.shields.io/badge/AppVersion-v2.7.0-informational?style=for-the-badge)
+![Version: 2.8.0](https://img.shields.io/badge/Version-2.8.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: v2.8.0](https://img.shields.io/badge/AppVersion-v2.8.0-informational?style=for-the-badge)
 
 ## Description 📜
 

--- a/deploy/quickstart/install.yaml
+++ b/deploy/quickstart/install.yaml
@@ -31333,7 +31333,7 @@ spec:
           value: 10s
         - name: KUBE_API_TIMEOUT
           value: 30s
-        image: pulumi/pulumi-kubernetes-operator:v2.7.0
+        image: pulumi/pulumi-kubernetes-operator:v2.8.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= v2.7.0
+VERSION ?= v2.8.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 images:
 - name: controller
   newName: pulumi/pulumi-kubernetes-operator
-  newTag: v2.7.0
+  newTag: v2.8.0
 resources:
 - manager.yaml

--- a/operator/version/version.go
+++ b/operator/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-var Version string = "v2.7.0"
+var Version string = "v2.8.0"


### PR DESCRIPTION
Cuts v2.8.0. Bumps version strings across the repo (via `make prep`), updates the Helm `Chart.yaml` / README badge, and moves the `## Unreleased` changelog items into a dated `2.8.0` section. `make codegen` produces no drift, so shipped CRDs and docs are current.

## Test plan
- CI codegen gate passes (no CRD/docs drift)
- Build and lint pass