### PR TITLE
Prepare release v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## Unreleased
 
+## 2.9.0 (2026-07-29)
+
 - Add `serviceTemplate` to the Workspace spec, allowing custom annotations and labels on the headless Service that fronts a workspace's pods; settable from a Stack via `spec.workspaceTemplate.spec.serviceTemplate.metadata` [#1280](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1280)
 
 ## 2.8.0 (2026-07-21)

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ A simple "quickstart" installation manifest is provided for non-production envir
 Install with `kubectl`:
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/pulumi/pulumi-kubernetes-operator/refs/tags/v2.8.0/deploy/quickstart/install.yaml
+kubectl apply -f https://raw.githubusercontent.com/pulumi/pulumi-kubernetes-operator/refs/tags/v2.9.0/deploy/quickstart/install.yaml
 ```
 
 ### From Source
 
 To build and install the operator from this repository:
 
-1. Build the operator image: `make build-image` (produces `pulumi/pulumi-kubernetes-operator:v2.8.0`).
+1. Build the operator image: `make build-image` (produces `pulumi/pulumi-kubernetes-operator:v2.9.0`).
 2. Push or load the image into your cluster's registry.
 3. Deploy to your current cluster context: `make deploy`.
 

--- a/agent/version/version.go
+++ b/agent/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-var Version string = "v2.8.0"
+var Version string = "v2.9.0"

--- a/deploy/deploy-operator-yaml/Pulumi.yaml
+++ b/deploy/deploy-operator-yaml/Pulumi.yaml
@@ -5,7 +5,7 @@ description: |
 config:
   version: # The version to install of the Pulumi Kubernetes Operator.
     type: string
-    default: v2.8.0
+    default: v2.9.0
 resources:
   pko:
     type: kubernetes:kustomize/v2:Directory

--- a/deploy/helm/pulumi-operator/Chart.yaml
+++ b/deploy/helm/pulumi-operator/Chart.yaml
@@ -9,8 +9,8 @@ icon: https://www.pulumi.com/logos/brand/avatar-on-white.svg
 
 type: application
 
-version: "2.8.0"
-appVersion: "v2.8.0"
+version: "2.9.0"
+appVersion: "v2.9.0"
 
 keywords:
   - pulumi
@@ -32,7 +32,7 @@ annotations:
     - New operator version
   artifacthub.io/images: |
     - name: pulumi-kubernetes-operator
-      image: docker.io/pulumi/pulumi-kubernetes-operator:v2.8.0
+      image: docker.io/pulumi/pulumi-kubernetes-operator:v2.9.0
       platforms:
         - linux/amd64
         - linux/arm64

--- a/deploy/helm/pulumi-operator/README.md
+++ b/deploy/helm/pulumi-operator/README.md
@@ -1,6 +1,6 @@
 # Pulumi Kubernetes Operator - Helm Chart
 
-![Version: 2.8.0](https://img.shields.io/badge/Version-2.8.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: v2.8.0](https://img.shields.io/badge/AppVersion-v2.8.0-informational?style=for-the-badge)
+![Version: 2.9.0](https://img.shields.io/badge/Version-2.9.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: v2.9.0](https://img.shields.io/badge/AppVersion-v2.9.0-informational?style=for-the-badge)
 
 ## Description 📜
 

--- a/deploy/quickstart/install.yaml
+++ b/deploy/quickstart/install.yaml
@@ -10660,6 +10660,26 @@ spec:
                         type: string
                       serviceAccountName:
                         type: string
+                      serviceTemplate:
+                        description: |-
+                          EmbeddedServiceTemplateSpecApplyConfiguration represents a declarative configuration of the EmbeddedServiceTemplateSpec type for use
+                          with apply.
+                        properties:
+                          metadata:
+                            description: |-
+                              EmbeddedObjectMetaApplyConfiguration represents a declarative configuration of the EmbeddedObjectMeta type for use
+                              with apply.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
                       stacks:
                         items:
                           description: |-
@@ -21271,6 +21291,26 @@ spec:
                         type: string
                       serviceAccountName:
                         type: string
+                      serviceTemplate:
+                        description: |-
+                          EmbeddedServiceTemplateSpecApplyConfiguration represents a declarative configuration of the EmbeddedServiceTemplateSpec type for use
+                          with apply.
+                        properties:
+                          metadata:
+                            description: |-
+                              EmbeddedObjectMetaApplyConfiguration represents a declarative configuration of the EmbeddedObjectMeta type for use
+                              with apply.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
                       stacks:
                         items:
                           description: |-
@@ -30735,6 +30775,36 @@ spec:
                 description: ServiceAccountName is the Kubernetes service account
                   identity of the workspace.
                 type: string
+              serviceTemplate:
+                description: |-
+                  ServiceTemplate defines a template for the Workspace's Service metadata.
+                  Use this to add annotations or labels to the headless Service that
+                  fronts the Workspace's pods.
+                properties:
+                  metadata:
+                    description: Metadata contains the labels and annotations to apply
+                      to the Service.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                type: object
               stacks:
                 description: List of stacks this workspace manages.
                 items:
@@ -31333,7 +31403,7 @@ spec:
           value: 10s
         - name: KUBE_API_TIMEOUT
           value: 30s
-        image: pulumi/pulumi-kubernetes-operator:v2.8.0
+        image: pulumi/pulumi-kubernetes-operator:v2.9.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= v2.8.0
+VERSION ?= v2.9.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ kind: Kustomization
 images:
 - name: controller
   newName: pulumi/pulumi-kubernetes-operator
-  newTag: v2.8.0
+  newTag: v2.9.0
 resources:
 - manager.yaml

--- a/operator/version/version.go
+++ b/operator/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-var Version string = "v2.8.0"
+var Version string = "v2.9.0"


### PR DESCRIPTION
Bumps version strings to v2.9.0 across the codebase (`make prep RELEASE=v2.9.0`) and rolls the `serviceTemplate` changelog entry into a dated 2.9.0 section. Minor bump for the new backward-compatible `serviceTemplate` Workspace field (#1280).

## Test plan
- `make prep RELEASE=v2.9.0` ran clean; no stray `v2.8.0` strings remain outside CHANGELOG history.
- `operator/version/version.go` and `agent/version/version.go` both report `v2.9.0`; Helm Chart `version`/`appVersion` bumped to `2.9.0`/`v2.9.0`.
- Merge, then tag the head `v2.9.0` and push the tag to trigger `.github/workflows/release.yaml`.