### PR TITLE
Fix Stack wedging when status.currentUpdate is never cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## Unreleased
 
+- Fix a Stack wedging permanently when `status.currentUpdate` was never cleared. If the `Update` is gone the stack controller now confirms the absence against the API server, adopts a still-running update if one is found, and otherwise clears the reference and starts a new one. If the `Update` is present and terminal it is absorbed even when its `observedGeneration` lags, which previously happened whenever a completed `Update` was deleted and made the Stack wait on a result that was already final [#1292](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1292)
+- Release the stack controller's finalizer from `Update` objects left in `Terminating`, including ones finalized by an older operator version whose finalizer the server-side apply could not remove — previously these could never finish deleting without hand-patching a controller-owned field [#1293](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1293)
+
 ## 2.9.0 (2026-07-29)
 
 - Add `serviceTemplate` to the Workspace spec, allowing custom annotations and labels on the headless Service that fronts a workspace's pods; settable from a Stack via `spec.workspaceTemplate.spec.serviceTemplate.metadata` [#1280](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1280)

--- a/operator/api/pulumi/v1/events.go
+++ b/operator/api/pulumi/v1/events.go
@@ -48,6 +48,7 @@ const (
 	StackUpdateFailure          StackEventReason = "StackUpdateFailure"
 	StackUpdateConflictDetected StackEventReason = "StackUpdateConflictDetected"
 	StackOutputRetrievalFailure StackEventReason = "StackOutputRetrievalFailure"
+	StackUpdateLost             StackEventReason = "StackUpdateLost"
 
 	// Normals
 
@@ -80,6 +81,13 @@ func StackUpdateConflictDetectedEvent() StackEvent {
 
 func StackOutputRetrievalFailureEvent() StackEvent {
 	return StackEvent{eventType: EventTypeWarning, reason: StackOutputRetrievalFailure}
+}
+
+// StackUpdateLostEvent reports that the Update named by .status.currentUpdate no longer
+// exists, so its outcome could not be recorded. The stack controller clears the reference
+// and starts a fresh update.
+func StackUpdateLostEvent() StackEvent {
+	return StackEvent{eventType: EventTypeWarning, reason: StackUpdateLost}
 }
 
 func StackUpdateDetectedEvent() StackEvent {

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -286,9 +286,10 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&pulumicontroller.StackReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("stack-controller"),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorderFor("stack-controller"),
+		APIReader: mgr.GetAPIReader(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Stack")
 		os.Exit(1)

--- a/operator/internal/controller/pulumi/stack_controller.go
+++ b/operator/internal/controller/pulumi/stack_controller.go
@@ -82,6 +82,8 @@ const (
 	fluxSourceIndexFieldName     = ".spec.fluxSource.sourceRef" // an arbitrary name, named for the field it indexes
 	ttlForCompletedUpdate        = time.Hour * 24
 	sourceUnavailableRequeueWait = 30 * time.Second // safety-net requeue in case a watch event is missed
+	updateCacheLagRequeue        = 5 * time.Second  // the current Update exists but hasn't reached our cache yet
+	updateInFlightRequeue        = 5 * time.Minute  // safety-net poll while an update is running
 )
 
 const (
@@ -98,6 +100,9 @@ const prerequisiteIndexFieldName = "spec.prerequisites.name"
 // SetupWithManager sets up the controller with the Manager.
 func (r *StackReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	var err error
+	if r.APIReader == nil {
+		r.APIReader = mgr.GetAPIReader()
+	}
 	blder := ctrl.NewControllerManagedBy(mgr).Named("stack-controller")
 	opts := controller.Options{}
 
@@ -438,8 +443,23 @@ func (workspaceReadyPredicate) Generic(_ event.GenericEvent) bool {
 	return false
 }
 
+// isUpdateComplete reports whether an Update has reached a terminal state, meaning its result is
+// final and can be absorbed into the owning Stack's status.
+//
+// This deliberately does not require .status.observedGeneration to match .metadata.generation.
+// Nothing ever writes an Update's status again once it is Complete -- the update controller
+// short-circuits on the Complete condition -- while the apiserver *does* bump generation when a
+// deletion is blocked by a finalizer. So an Update that completes and is then deleted (by its
+// TTL, or by a workspace cascade) ends up permanently at generation N+1 with observedGeneration
+// N. Requiring them to match made such an Update look forever unfinished, which left the owning
+// Stack waiting on it indefinitely and, because the Stack removes the finalizer only after
+// absorbing the result, left the Update stuck Terminating as well.
+//
+// Ignoring observedGeneration is safe here because an Update's spec is never modified after
+// creation, so a generation bump cannot mean the recorded result is stale.
+// See https://github.com/pulumi/pulumi-kubernetes-operator/issues/1292.
 func isUpdateComplete(update *autov1alpha1.Update) bool {
-	if update == nil || update.Generation != update.Status.ObservedGeneration {
+	if update == nil {
 		return false
 	}
 	return meta.IsStatusConditionTrue(update.Status.Conditions, autov1alpha1.UpdateConditionTypeComplete)
@@ -475,6 +495,11 @@ type StackReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+
+	// APIReader reads directly from the apiserver, bypassing the cache. It is used to
+	// confirm that an Update named by .status.currentUpdate is really gone, rather than
+	// merely absent from a stale cache, before the reference is cleared.
+	APIReader client.Reader
 
 	// this is initialised by add(), to be available to Reconcile
 	maybeWatchFluxSourceKind func(shared.FluxSourceReference) error
@@ -600,16 +625,28 @@ func (r *StackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 				"conditions", instance.Status.Conditions)
 		}
 		if toBeFinalized != nil {
-			// Remove the finalizer from the Update object using SSA. This is best-effort
-			// since the status update (indicating the update was processed) has already
-			// completed. If removal fails, the Update will be cleaned up by TTL or manual
-			// intervention.
+			// Remove the finalizer from the Update object using SSA. This is best-effort since
+			// the status update (indicating the update was processed) has already completed.
+			// A failure here is not lost: reapTerminatingUpdates picks up any Update left
+			// holding the finalizer on a later reconcile. It must, because a TTL or cascade
+			// delete cannot complete while the finalizer is present -- the object parks in
+			// Terminating indefinitely.
 			if err := r.removeUpdateFinalizer(ctx, toBeFinalized); err != nil {
 				log.Error(err, "unable to remove finalizer from current update (best-effort)")
 			}
 			toBeFinalized = nil
 		}
 		return nil
+	}
+
+	// Release any Update that is being deleted but still holds our finalizer. Normally the
+	// finalizer is dropped as soon as the Stack absorbs the result, but if that write failed --
+	// or was skipped by an older version of the operator -- the object cannot finish deleting,
+	// and freeing it otherwise requires an operator to force-patch a controller-owned field.
+	// See https://github.com/pulumi/pulumi-kubernetes-operator/issues/1293.
+	if err := r.reapTerminatingUpdates(ctx, instance, request.Namespace); err != nil {
+		// Not fatal to this reconcile: the sweep is idempotent and runs again next time.
+		log.Error(err, "unable to release finalizers from deleted updates (best-effort)")
 	}
 
 	// Check for an outstanding update, and absorb the result into status if the update is complete.
@@ -619,20 +656,37 @@ func (r *StackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 			Namespace: request.Namespace,
 		}); err != nil {
 			if apierrors.IsNotFound(err) {
-				// the cache is probably out of date; wait for a watch event.
-				log.Info("update object not found; will retry", "Name", instance.Status.CurrentUpdate.Name)
+				// The Update is missing from the cache. That is usually just cache lag, but it
+				// can also mean the object is genuinely gone -- in which case no watch event
+				// will ever arrive and waiting would wedge the Stack forever. Confirm against
+				// the apiserver before deciding.
+				missing, rerr := r.updateIsGone(ctx, types.NamespacedName{
+					Name:      instance.Status.CurrentUpdate.Name,
+					Namespace: request.Namespace,
+				})
+				if rerr != nil {
+					return reconcile.Result{}, fmt.Errorf("confirming current update is gone: %w", rerr)
+				}
 				instance.Status.MarkReconcilingCondition(pulumiv1.ReconcilingProcessingReason, pulumiv1.ReconcilingProcessingUpdateMessage)
-				return reconcile.Result{}, saveStatus()
+				if !missing {
+					// The object does exist (possibly Terminating); the cache is behind. Retry
+					// shortly rather than relying solely on a watch event we may have missed.
+					log.Info("update object not in cache but present in the API; will retry",
+						"Name", instance.Status.CurrentUpdate.Name)
+					return reconcile.Result{RequeueAfter: updateCacheLagRequeue}, saveStatus()
+				}
+				return r.healLostUpdate(ctx, instance, request.Namespace, saveStatus)
 			}
 			return reconcile.Result{}, fmt.Errorf("get current update: %w", err)
 		}
 
-		completed := sess.update.Generation == sess.update.Status.ObservedGeneration &&
-			meta.IsStatusConditionTrue(sess.update.Status.Conditions, autov1alpha1.UpdateConditionTypeComplete)
-		if !completed {
-			// wait for the update to complete
+		if !isUpdateComplete(sess.update) {
+			// Wait for the update to complete. The Update watch normally drives this, but
+			// requeue on a slow timer as well so that an Update which never reaches a terminal
+			// state cannot strand the Stack. Keep this coarse: each pass re-resolves the
+			// source, which for a git source means a network round trip.
 			instance.Status.MarkReconcilingCondition(pulumiv1.ReconcilingProcessingReason, pulumiv1.ReconcilingProcessingUpdateMessage)
-			return reconcile.Result{}, saveStatus()
+			return reconcile.Result{RequeueAfter: updateInFlightRequeue}, saveStatus()
 		}
 
 		// The update is complete. If it failed, we need to mark the stack as failed.
@@ -1054,9 +1108,14 @@ func (r *StackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 	err = r.Create(ctx, update, client.FieldOwner(FieldManager))
 	if err != nil {
 		// the update object couldn't be created; remove the currentUpdate and try again later.
+		// The status write must not be dropped: if it fails silently, .status.currentUpdate is
+		// left naming an Update that may never exist, which wedges the Stack permanently.
 		log.Error(err, "failed to create an Update for the stack; will retry later")
 		instance.Status.CurrentUpdate = nil
-		_ = saveStatus()
+		if serr := saveStatus(); serr != nil {
+			return reconcile.Result{}, fmt.Errorf(
+				"unable to create update for stack: %w (and clearing the current update failed: %w)", err, serr)
+		}
 		return reconcile.Result{}, fmt.Errorf("unable to create update for stack: %w", err)
 	}
 
@@ -1067,8 +1126,13 @@ func (r *StackReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 		log.Error(err, "failed to add finalizer to Update")
 		// Delete the update since we couldn't finalize it properly
 		_ = r.Delete(ctx, update)
+		// As above, dropping this status write would leave .status.currentUpdate naming an
+		// Update we just deleted, which wedges the Stack permanently.
 		instance.Status.CurrentUpdate = nil
-		_ = saveStatus()
+		if serr := saveStatus(); serr != nil {
+			return reconcile.Result{}, fmt.Errorf(
+				"unable to add finalizer to update: %w (and clearing the current update failed: %w)", err, serr)
+		}
 		return reconcile.Result{}, fmt.Errorf("unable to add finalizer to update: %w", err)
 	}
 
@@ -1897,6 +1961,155 @@ func (sess *stackReconcilerSession) setOwnerReferences(o *pulumiv1.Stack, update
 
 func makeUpdateName(o *pulumiv1.Stack) string {
 	return fmt.Sprintf("%s-%x", o.Name, time.Now().UnixMilli())
+}
+
+// updateIsGone reports whether the named Update is really absent, by reading straight from
+// the apiserver rather than the (possibly stale) cache. An object that exists but is
+// Terminating is reported as present: its deletion bumps .metadata.generation, which wakes
+// the update controller, which drives it to a terminal state that this controller can then
+// absorb normally.
+func (r *StackReconciler) updateIsGone(ctx context.Context, name types.NamespacedName) (bool, error) {
+	u := &autov1alpha1.Update{}
+	err := r.APIReader.Get(ctx, name, u)
+	if apierrors.IsNotFound(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+// healLostUpdate recovers a Stack whose .status.currentUpdate names an Update that no longer
+// exists. Without this the Stack retries against an object that can never come back and stops
+// reconciling its resources entirely.
+//
+// If an in-flight Update for this Stack is still around -- which happens when the reference was
+// lost rather than the object -- it is adopted instead of being abandoned, so that we do not
+// start a second concurrent pulumi operation against the same workspace.
+//
+// Otherwise the reference is cleared and an error is returned. Returning an error is
+// deliberate: it puts the Stack on the workqueue's exponential backoff, so that an Update
+// which is being deleted systemically (for example because its Workspace is gone, and every
+// replacement is cascade-deleted in turn) cannot become an unbounded create/delete loop. The
+// retry then takes the ordinary path and creates a fresh Update.
+//
+// .status.lastUpdate is deliberately left alone. The real outcome of the lost update is
+// unknown -- most often it never ran at all -- so recording a synthetic failure would both
+// misreport history and spend the Stack's retry budget (maxUpdateFailures) on an operator-side
+// fault. Leaving it untouched lets isSynced correctly see the Stack as out of sync.
+func (r *StackReconciler) healLostUpdate(
+	ctx context.Context,
+	instance *pulumiv1.Stack,
+	namespace string,
+	saveStatus func() error,
+) (reconcile.Result, error) {
+	log := ctrllog.FromContext(ctx)
+	lostName := instance.Status.CurrentUpdate.Name
+
+	adopted, err := r.findInFlightUpdate(ctx, instance, namespace)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("looking for an in-flight update to adopt: %w", err)
+	}
+	if adopted != nil {
+		log.Info("current update object not found, but an in-flight update exists; adopting it",
+			"Name", lostName, "AdoptedName", adopted.Name)
+		instance.Status.CurrentUpdate.Name = adopted.Name
+		return reconcile.Result{RequeueAfter: updateCacheLagRequeue}, saveStatus()
+	}
+
+	log.Info("current update object no longer exists; clearing it and starting a new update",
+		"Name", lostName)
+	emitEvent(r.Recorder, instance, pulumiv1.StackUpdateLostEvent(),
+		"The update %q no longer exists; its result could not be recorded. Starting a new update.", lostName)
+	instance.Status.CurrentUpdate = nil
+	if err := saveStatus(); err != nil {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, fmt.Errorf("update %q no longer exists; cleared it to start a new update", lostName)
+}
+
+// reapTerminatingUpdates removes this controller's finalizer from the Stack's Updates that are
+// being deleted and have already reached a terminal state.
+//
+// The finalizer exists so that a completed Update survives long enough for the Stack to record
+// its result. Once the Update is terminal that purpose is served, and holding on cannot help:
+// there is no operation left to cancel, so an Update kept in Terminating is strictly worse than
+// one that is gone. Updates that are not yet terminal are left alone -- the update controller
+// marks those Canceled first, and this sweep collects them on a later pass.
+func (r *StackReconciler) reapTerminatingUpdates(ctx context.Context, instance *pulumiv1.Stack, namespace string) error {
+	log := ctrllog.FromContext(ctx)
+
+	updates := &autov1alpha1.UpdateList{}
+	if err := r.List(ctx, updates,
+		client.InNamespace(namespace),
+		client.MatchingLabels(labelsForWorkspace(&instance.ObjectMeta)),
+	); err != nil {
+		return err
+	}
+
+	var errs []error
+	for i := range updates.Items {
+		u := &updates.Items[i]
+		if u.DeletionTimestamp.IsZero() || !slices.Contains(u.Finalizers, PulumiFinalizer) {
+			continue
+		}
+		// Don't release the update we are still waiting on a result from.
+		if instance.Status.CurrentUpdate != nil && instance.Status.CurrentUpdate.Name == u.Name {
+			continue
+		}
+		if !isUpdateComplete(u) {
+			continue
+		}
+		log.Info("Releasing finalizer from a deleted update", "Name", u.Name)
+		// Read-modify-write rather than the SSA apply used on the happy path. The apply only
+		// drops the finalizer when StackFinalizerFieldManager owns it, so a finalizer written
+		// by an older operator version -- under the shared field manager -- would silently
+		// survive, which is one of the ways an Update ends up unable to delete at all. A
+		// conflict here just means the next reconcile tries again.
+		if !controllerutil.RemoveFinalizer(u, PulumiFinalizer) {
+			continue
+		}
+		if err := r.Update(ctx, u, client.FieldOwner(FieldManager)); err != nil {
+			if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("releasing finalizer from update %q: %w", u.Name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// findInFlightUpdate returns the Stack's own Update that is still running, if there is exactly
+// one. Anything complete, being deleted, or ambiguous yields nil so that the caller falls back
+// to starting a fresh update.
+func (r *StackReconciler) findInFlightUpdate(
+	ctx context.Context,
+	instance *pulumiv1.Stack,
+	namespace string,
+) (*autov1alpha1.Update, error) {
+	updates := &autov1alpha1.UpdateList{}
+	if err := r.APIReader.List(ctx, updates,
+		client.InNamespace(namespace),
+		client.MatchingLabels(labelsForWorkspace(&instance.ObjectMeta)),
+	); err != nil {
+		return nil, err
+	}
+
+	var found *autov1alpha1.Update
+	for i := range updates.Items {
+		u := &updates.Items[i]
+		if !u.DeletionTimestamp.IsZero() || isUpdateComplete(u) {
+			continue
+		}
+		if found != nil {
+			// More than one candidate: we cannot tell which (if either) belongs to this
+			// Stack's lost reference, so don't guess.
+			return nil, nil
+		}
+		found = u
+	}
+	return found, nil
 }
 
 func (sess *stackReconcilerSession) readCurrentUpdate(ctx context.Context, name types.NamespacedName) error {

--- a/operator/internal/controller/pulumi/stack_controller_test.go
+++ b/operator/internal/controller/pulumi/stack_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -185,6 +186,20 @@ func makeUpdate(name types.NamespacedName, stack *pulumiv1.Stack, spec autov1alp
 	}
 }
 
+// updateHidingClient is a cached-client stand-in that reports one named Update as absent,
+// reproducing a cold or lagging informer while the object really does exist in the API.
+type updateHidingClient struct {
+	client.Client
+	hidden string
+}
+
+func (c updateHidingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*autov1alpha1.Update); ok && key.Name == c.hidden {
+		return apierrors.NewNotFound(autov1alpha1.GroupVersion.WithResource("updates").GroupResource(), key.Name)
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
 var _ = Describe("Stack Controller", func() {
 	var r *StackReconciler
 	var objName types.NamespacedName
@@ -197,9 +212,10 @@ var _ = Describe("Stack Controller", func() {
 
 	BeforeEach(func(ctx context.Context) {
 		r = &StackReconciler{
-			Client:   k8sClient,
-			Scheme:   k8sClient.Scheme(),
-			Recorder: record.NewFakeRecorder(10),
+			Client:    k8sClient,
+			APIReader: k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Recorder:  record.NewFakeRecorder(10),
 			maybeWatchFluxSourceKind: func(fsr shared.FluxSourceReference) error {
 				return nil
 			},
@@ -556,23 +572,91 @@ var _ = Describe("Stack Controller", func() {
 			}
 		})
 
-		When("the update is not found", func() {
+		When("the update is gone", func() {
+			var lostName string
 			JustBeforeEach(func(ctx context.Context) {
+				lostName = currentUpdate.Name
 				currentUpdate.Finalizers = []string{}
 				Expect(k8sClient.Update(ctx, currentUpdate)).To(Succeed())
 				Expect(k8sClient.Delete(ctx, currentUpdate)).To(Succeed())
 			})
-			It("reconciles", func(ctx context.Context) {
+			It("clears the reference so a new update can start", func(ctx context.Context) {
+				_, err := reconcileF(ctx)
+
+				By("returning an error to put the Stack on the workqueue's backoff")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(lostName))
+
+				By("clearing the current update")
+				Expect(obj.Status.CurrentUpdate).To(BeNil())
+
+				By("leaving the last update untouched, to preserve the retry budget")
+				Expect(obj.Status.LastUpdate).To(BeNil())
+
+				By("emitting an event so the condition is distinguishable from a healthy Stack")
+				Expect(r.Recorder.(*record.FakeRecorder).Events).To(Receive(
+					ContainSubstring(string(pulumiv1.StackUpdateLost))))
+			})
+
+			It("starts a fresh update on the following reconcile", func(ctx context.Context) {
+				_, err := reconcileF(ctx)
+				Expect(err).To(HaveOccurred())
+				Expect(obj.Status.CurrentUpdate).To(BeNil())
+
+				// The retry needs a ready workspace to get as far as creating an Update.
+				ws.Status.ObservedGeneration = ws.Generation
+				ws.Status.Conditions = []metav1.Condition{
+					{Type: "Ready", Status: metav1.ConditionTrue, Reason: "Succeeded", LastTransitionTime: metav1.Now()},
+				}
+				Expect(k8sClient.Status().Update(ctx, ws, client.FieldOwner(FieldManager))).To(Succeed())
+
+				_, err = reconcileF(ctx)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("naming a different update than the one that was lost")
+				Expect(obj.Status.CurrentUpdate).NotTo(BeNil())
+				Expect(obj.Status.CurrentUpdate.Name).NotTo(Equal(lostName))
+			})
+		})
+
+		When("the update is missing from the cache but present in the API", func() {
+			It("retains the reference and retries", func(ctx context.Context) {
+				// Reconcile with an APIReader that still sees the object, but a cached client
+				// that does not -- the situation a cold or lagging informer produces.
+				r.Client = updateHidingClient{Client: k8sClient, hidden: currentUpdate.Name}
+
 				result, err := reconcileF(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
 				ByMarkingAsReconciling(pulumiv1.ReconcilingProcessingReason, Equal(pulumiv1.ReconcilingProcessingUpdateMessage))
 
-				By("retaining the current update")
+				By("retaining the current update rather than starting a second one")
 				Expect(obj.Status.CurrentUpdate).NotTo(BeNil())
+				Expect(obj.Status.CurrentUpdate.Name).To(Equal(currentUpdate.Name))
 
-				By("not requeuing and by watching for Update status changes")
-				Expect(result).To(Equal(reconcile.Result{}))
+				By("requeuing so a missed watch event cannot strand the Stack")
+				Expect(result.RequeueAfter).To(Equal(updateCacheLagRequeue))
+			})
+		})
+
+		When("the reference is lost but the update itself is still running", func() {
+			var orphanName string
+			JustBeforeEach(func(ctx context.Context) {
+				// The Stack's Update is alive and unfinished, but .status.currentUpdate names
+				// something that never existed -- the shape produced when the status write that
+				// recorded the reference was lost.
+				orphanName = currentUpdate.Name
+				obj.Status.CurrentUpdate.Name = "does-not-exist"
+				Expect(k8sClient.Status().Patch(ctx, obj, stackStatusSSAPatch(obj),
+					client.FieldOwner(StackStatusFieldManager), client.ForceOwnership)).To(Succeed())
+			})
+			It("adopts it instead of starting a second pulumi operation", func(ctx context.Context) {
+				result, err := reconcileF(ctx)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(obj.Status.CurrentUpdate).NotTo(BeNil())
+				Expect(obj.Status.CurrentUpdate.Name).To(Equal(orphanName))
+				Expect(result.RequeueAfter).To(Equal(updateCacheLagRequeue))
 			})
 		})
 
@@ -597,8 +681,109 @@ var _ = Describe("Stack Controller", func() {
 				By("retaining the current update")
 				Expect(obj.Status.CurrentUpdate).NotTo(BeNil())
 
-				By("not requeuing and by watching for Update status changes")
-				Expect(result).To(Equal(reconcile.Result{}))
+				By("polling on a slow timer so a stuck Update cannot strand the Stack")
+				Expect(result).To(Equal(reconcile.Result{RequeueAfter: updateInFlightRequeue}))
+			})
+		})
+
+		// An Update that completed and was then deleted sits at generation N+1 with
+		// observedGeneration N forever: the apiserver bumps generation when the Stack's finalizer
+		// blocks the deletion, and nothing writes an Update's status again once it is Complete.
+		// Requiring the two to match left the Stack waiting on a result that was already final --
+		// and because the Stack drops the finalizer only after absorbing it, left the Update
+		// stuck Terminating too. See https://github.com/pulumi/pulumi-kubernetes-operator/issues/1292.
+		When("the update is terminal but its generation was bumped by a blocked deletion", func() {
+			BeforeEach(func(ctx context.Context) {
+				currentUpdate.Status.ObservedGeneration = 1
+				currentUpdate.Status.Conditions = []metav1.Condition{
+					{
+						Type:               autov1alpha1.UpdateConditionTypeComplete,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Updated",
+						LastTransitionTime: metav1.Now(),
+					},
+					{
+						Type:               autov1alpha1.UpdateConditionTypeFailed,
+						Status:             metav1.ConditionTrue,
+						Reason:             "unknown",
+						LastTransitionTime: metav1.Now(),
+					},
+				}
+			})
+			JustBeforeEach(func(ctx context.Context) {
+				// Deleting an Update that still carries the Stack's finalizer leaves it
+				// Terminating with generation bumped past observedGeneration.
+				Expect(k8sClient.Delete(ctx, currentUpdate)).To(Succeed())
+				live := &autov1alpha1.Update{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(currentUpdate), live)).To(Succeed())
+				Expect(live.DeletionTimestamp).NotTo(BeNil())
+				Expect(live.Generation).To(BeNumerically(">", live.Status.ObservedGeneration))
+			})
+			It("absorbs the result rather than waiting on it forever", func(ctx context.Context) {
+				_, err := reconcileF(ctx)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("clearing the current update")
+				Expect(obj.Status.CurrentUpdate).To(BeNil())
+
+				By("recording the terminal result")
+				Expect(obj.Status.LastUpdate).NotTo(BeNil())
+				Expect(obj.Status.LastUpdate.State).To(Equal(shared.FailedStackStateMessage))
+			})
+		})
+
+		// An Update left Terminating with our finalizer can never finish deleting, and freeing it
+		// otherwise means force-patching a controller-owned field by hand.
+		//
+		// The finalizer here is written by a plain Create rather than by SSA under
+		// StackFinalizerFieldManager, which models the harder case: an Update finalized by an
+		// older operator version. The happy-path SSA apply cannot remove a finalizer it does not
+		// own, so the sweep has to be ownership-agnostic.
+		// See https://github.com/pulumi/pulumi-kubernetes-operator/issues/1293.
+		When("a previous update is stuck Terminating with our finalizer", func() {
+			var stuck *autov1alpha1.Update
+			JustBeforeEach(func(ctx context.Context) {
+				stuck = makeUpdate(objName, obj, autov1alpha1.UpdateSpec{
+					WorkspaceName: nameForWorkspace(&obj.ObjectMeta),
+					StackName:     obj.Spec.Stack,
+					Type:          autov1alpha1.UpType,
+				})
+				Expect(controllerutil.SetControllerReference(obj, stuck, k8sClient.Scheme())).To(Succeed())
+				Expect(k8sClient.Create(ctx, stuck)).To(Succeed())
+				stuck.Status.Conditions = []metav1.Condition{{
+					Type:               autov1alpha1.UpdateConditionTypeComplete,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Updated",
+					LastTransitionTime: metav1.Now(),
+				}}
+				Expect(k8sClient.Status().Update(ctx, stuck)).To(Succeed())
+				Expect(k8sClient.Delete(ctx, stuck)).To(Succeed())
+
+				live := &autov1alpha1.Update{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(stuck), live)).To(Succeed())
+				Expect(live.Finalizers).To(ContainElement(PulumiFinalizer))
+			})
+			It("releases the finalizer so the object can finish deleting", func(ctx context.Context) {
+				_, _ = reconcileF(ctx)
+
+				live := &autov1alpha1.Update{}
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(stuck), live)
+				if err == nil {
+					Expect(live.Finalizers).NotTo(ContainElement(PulumiFinalizer))
+				} else {
+					Expect(apierrors.IsNotFound(err)).To(BeTrue(), "the update should be gone once released")
+				}
+			})
+			It("does not release the update it is still waiting on", func(ctx context.Context) {
+				// currentUpdate names a different, still-running Update; it must be untouched.
+				live := &autov1alpha1.Update{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(currentUpdate), live)).To(Succeed())
+				Expect(live.Finalizers).To(ContainElement(PulumiFinalizer))
+
+				_, _ = reconcileF(ctx)
+
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(currentUpdate), live)).To(Succeed())
+				Expect(live.Finalizers).To(ContainElement(PulumiFinalizer))
 			})
 		})
 
@@ -2845,9 +3030,10 @@ func TestWorkspaceStalledPropagation(t *testing.T) {
 
 			// 4. Reconcile.
 			r := &StackReconciler{
-				Client:   k8sclient,
-				Scheme:   testScheme,
-				Recorder: record.NewFakeRecorder(10),
+				Client:    k8sclient,
+				APIReader: k8sclient,
+				Scheme:    testScheme,
+				Recorder:  record.NewFakeRecorder(10),
 			}
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: stackName})
 			require.NoError(t, err)
@@ -2930,9 +3116,10 @@ func TestProjectInfoDestroyBypassesUnavailableSource(t *testing.T) {
 	require.NoError(t, k8sclient.Delete(ctx, stack))
 
 	r := &StackReconciler{
-		Client:   k8sclient,
-		Scheme:   testScheme,
-		Recorder: record.NewFakeRecorder(10),
+		Client:    k8sclient,
+		APIReader: k8sclient,
+		Scheme:    testScheme,
+		Recorder:  record.NewFakeRecorder(10),
 	}
 
 	// First reconcile: takes the projectInfo bypass and applies a projectInfo workspace,
@@ -3045,7 +3232,7 @@ func TestFailedDestroyRetainsFinalizer(t *testing.T) {
 	}
 	require.NoError(t, k8sclient.Status().Update(ctx, stack))
 
-	r := &StackReconciler{Client: k8sclient, Scheme: testScheme, Recorder: record.NewFakeRecorder(10)}
+	r := &StackReconciler{Client: k8sclient, APIReader: k8sclient, Scheme: testScheme, Recorder: record.NewFakeRecorder(10)}
 	_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: stackName})
 	require.NoError(t, err)
 
@@ -3137,9 +3324,10 @@ func TestStackDestroyStalledWhenNamespaceTerminating(t *testing.T) {
 
 	recorder := record.NewFakeRecorder(10)
 	r := &StackReconciler{
-		Client:   k8sclient,
-		Scheme:   testScheme,
-		Recorder: recorder,
+		Client:    k8sclient,
+		APIReader: k8sclient,
+		Scheme:    testScheme,
+		Recorder:  recorder,
 	}
 	_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: stackName})
 	require.NoError(t, err)
@@ -3224,9 +3412,10 @@ func TestStackStatusConcurrentModification(t *testing.T) {
 	require.NoError(t, k8sClient.Create(ctx, stack))
 
 	reconciler := &StackReconciler{
-		Client:   k8sClient,
-		Scheme:   testScheme,
-		Recorder: record.NewFakeRecorder(10),
+		Client:    k8sClient,
+		APIReader: k8sClient,
+		Scheme:    testScheme,
+		Recorder:  record.NewFakeRecorder(10),
 	}
 
 	// Step 3: First reconciliation — writes status via SSA.


### PR DESCRIPTION
### Proposed changes

A `Stack` could be left with `status.currentUpdate` naming an `Update` that would never resolve, after which it never started another update — `Reconciling=True` / `Ready=False` indefinitely, with the resources it manages silently unreconciled. #1292 reports 77 wedged Stacks across two clusters, the oldest at 174h, each managing live DNS records.

Two shapes, same effect and same manual recovery.

#### Shape A — the Update was garbage-collected

`stack_controller.go` logged `update object not found; will retry` and returned with **no requeue and without clearing the reference**, so nothing self-healed. The `pulumi.com/reconciliation-request` annotation could not rescue it either: the check runs *before* any sync logic, and `observedReconcileRequest` is persisted by that same branch — so the request was marked observed with nothing done.

- Absence is now confirmed against the API server via an uncached reader, since `readCurrentUpdate` goes through the cache and `IsNotFound` there only means "not in the informer". A cold or lagging cache is no longer mistaken for a deleted object.
- An Update that exists but is `Terminating` is left alone: its deletion bumps `generation`, which wakes the update controller, which drives it to a terminal state this controller can absorb normally.
- If the Stack's own update is still running it is **adopted** rather than abandoned, so we never start a second concurrent `pulumi` operation against one workspace.
- Otherwise the reference is cleared, a new `StackUpdateLost` event is emitted, and an error is returned so the retry goes through the workqueue's exponential backoff. That backoff is load-bearing: returning `nil` makes controller-runtime `Forget()` the item and reset the rate limiter, so an Update being deleted *systemically* (its Workspace is gone, and every replacement is cascade-deleted in turn) would become an unbounded create/delete loop.

`status.lastUpdate` is deliberately left untouched. The lost update's real outcome is unknown — most often it never ran — so recording a synthetic failure would both misreport history and spend the Stack's retry budget (`maxUpdateFailures`) on an operator-side fault. Visibility comes from the event and condition message instead, which is the "nothing distinguishes this from a healthy Stack" complaint in the issue.

#### Shape B — the Update was present and terminal, but never processed

Here `lastUpdate` still described the *previous* update — often a successful one — so the Stack looked healthy while being completely stuck.

The cause is a generation gate. `isUpdateComplete` required `status.observedGeneration == metadata.generation`, but:

- nothing writes an Update's status once it is `Complete` — the update controller short-circuits on that condition and returns without calling `updateStatus`; while
- the apiserver **bumps `generation`** when a deletion is blocked by a finalizer (`registry/store.go`, generation is incremented on the transition into deleting).

So an Update that completes and is then deleted — by its TTL, or by a workspace cascade — sits at generation N+1 / observedGeneration N *permanently*, looking forever unfinished. The issue hypothesised "a missed edge on the completion watch"; it is slightly worse than that, because `updateCompletePredicate` uses the same helper, so `Create` returned false for such an Update and **operator restarts did not even enqueue the Stack**. The edge was unreachable, not merely missed.

The gate is dropped. This is safe because an Update's spec is never modified after creation, so a generation bump cannot mean the recorded result is stale.

#### Two windows that needed no crash at all

The recovery paths after a failed `Create` and a failed `addUpdateFinalizer` both did `_ = saveStatus()`. A conflict on either left `status.currentUpdate` naming an Update that was deleted or never created — no crash required, which likely makes these the highest-probability cause in a busy fleet. Those errors are now returned.

#### Releasing Updates stuck in `Terminating`

Also sweeps Updates that are being deleted while still holding `finalizer.stack.pulumi.com`, which can otherwise never finish deleting. The sweep uses a read-modify-write rather than the happy path's server-side apply, because that apply can only drop a finalizer owned by its own field manager — so a finalizer written by an older operator version survives silently, leaving an object removable only by hand-patching a controller-owned field. (This is what the unused `isFinalizerOwnedByLegacyManager` helper was anticipating.) It skips the update currently being waited on, and skips non-terminal ones, which the update controller marks `Canceled` first.

This part addresses the deletion deadlock described in #1293 rather than #1292, but it lives in the same function as the changes above; splitting it out would mean two PRs editing `saveStatus`/`Reconcile` concurrently. Its changelog entry cites #1293 accordingly.

#### Also

Requeue on a slow timer while an update is in flight, so an Update that never reaches a terminal state cannot strand the Stack. Kept coarse (5m) because each pass re-resolves the source, which for a git source is a network round trip per in-flight Stack.

### Testing

New envtest specs in `stack_controller_test.go`:

- the Update is gone → reference cleared, event emitted, error returned; a fresh Update on the following reconcile
- the Update is absent from the cache but present in the API → reference **retained**, requeued, no duplicate Update (guards the regression this fix could introduce)
- the reference is lost while the update is still running → adopted, not duplicated
- the Update is terminal but its generation was bumped by a blocked deletion → result absorbed instead of waited on forever
- a previous Update stuck `Terminating` with a legacy-owned finalizer → released; and the update still being waited on → untouched
- `lastUpdate.Failures` unchanged across a heal

I confirmed the shape-B and reaper specs fail against the pre-fix code rather than passing vacuously.

`make test` (operator + agent) and `golangci-lint` are clean, with no codegen drift. `make test-e2e` has **not** been run, and neither failure mode has been reproduced end-to-end against a live cluster.

### Related issues

Fixes #1292. The finalizer sweep also addresses the deletion deadlock in #1293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
