### PR TITLE
Bound how long a wedged Update can hold a reconcile worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## Unreleased
 
+- Stop a wedged `Update` from holding one of the operator's reconcile workers indefinitely: add an idle timeout (`--update-idle-timeout`, `Update.spec.idleTimeout`) that abandons an update producing no output, tighten TCP keepalive on connections to workspace pods, give the update controller its own concurrency budget (`--update-max-concurrent-reconciles`), and honour the previously-ignored `GRACEFUL_SHUTDOWN_TIMEOUT_DURATION` [#1293](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1293)
+- Add a `--max-concurrent-reconciles` flag and stop silently ignoring malformed values of `MAX_CONCURRENT_RECONCILES` and the other environment overrides, which could drop the operator to a single worker with nothing in the logs [#1293](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1293)
+
 ## 2.9.0 (2026-07-29)
 
 - Add `serviceTemplate` to the Workspace spec, allowing custom annotations and labels on the headless Service that fronts a workspace's pods; settable from a Stack via `spec.workspaceTemplate.spec.serviceTemplate.metadata` [#1280](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1280)

--- a/agent/pkg/server/grpc.go
+++ b/agent/pkg/server/grpc.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"net"
+	"time"
 
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
@@ -24,6 +25,14 @@ import (
 	pb "github.com/pulumi/pulumi-kubernetes-operator/v2/agent/pkg/proto"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+)
+
+const (
+	// keepaliveTime is how long the server waits for traffic before pinging the client, and
+	// keepaliveTimeout is how long it then waits for the reply before closing the transport.
+	keepaliveTime    = 30 * time.Second
+	keepaliveTimeout = 20 * time.Second
 )
 
 // GRPC serves the automation service.
@@ -54,6 +63,21 @@ func NewGRPC(rootLogger *zap.SugaredLogger, server *Server, authF grpc_auth.Auth
 
 	// Create the gRPC server.
 	s := grpc.NewServer(
+		// Probe the client during long-running operations. A Pulumi operation streams for as
+		// long as it takes, and can be silent for minutes at a stretch, so without probes a
+		// disappeared operator leaves the handler -- and the `pulumi` subprocess it started --
+		// running with nobody to deliver the result to. Detecting it closes the transport,
+		// which cancels the stream context and lets the operation unwind.
+		//
+		// Server-initiated pings are not subject to any keepalive enforcement policy, so this
+		// needs no cooperation from the client and is safe against every operator version. Note
+		// that no EnforcementPolicy is set here on purpose: tightening the policy's MinTime
+		// would let this agent reject pings from a client that is behaving correctly for the
+		// default policy it was written against.
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    keepaliveTime,
+			Timeout: keepaliveTimeout,
+		}),
 		grpc.ChainUnaryInterceptor(
 			grpc_ctxtags.UnaryServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
 			grpc_zap.UnaryServerInterceptor(log.Desugar(), serverOpts...),

--- a/deploy/crds/auto.pulumi.com_updates.yaml
+++ b/deploy/crds/auto.pulumi.com_updates.yaml
@@ -77,6 +77,15 @@ spec:
               expectNoChanges:
                 description: Return an error if any changes occur during this update
                 type: boolean
+              idleTimeout:
+                description: |-
+                  IdleTimeout is how long the update may produce no output at all before the operator
+                  gives up on it and marks it failed. It bounds the time a wedged update can hold one of
+                  the operator's reconcile workers, which is otherwise occupied for the whole operation.
+                  Because it measures silence rather than total duration, a slow but progressing update
+                  is never interrupted. Zero disables the timeout. Defaults to the operator's
+                  --update-idle-timeout.
+                type: string
               message:
                 description: Message (optional) to associate with the preview operation
                 type: string

--- a/deploy/crds/pulumi.com_stacks.yaml
+++ b/deploy/crds/pulumi.com_stacks.yaml
@@ -1098,6 +1098,8 @@ spec:
                         type: boolean
                       expectNoChanges:
                         type: boolean
+                      idleTimeout:
+                        type: string
                       message:
                         type: string
                       parallel:
@@ -11729,6 +11731,8 @@ spec:
                         type: boolean
                       expectNoChanges:
                         type: boolean
+                      idleTimeout:
+                        type: string
                       message:
                         type: string
                       parallel:

--- a/deploy/helm/pulumi-operator/crds/auto.pulumi.com_updates.yaml
+++ b/deploy/helm/pulumi-operator/crds/auto.pulumi.com_updates.yaml
@@ -77,6 +77,15 @@ spec:
               expectNoChanges:
                 description: Return an error if any changes occur during this update
                 type: boolean
+              idleTimeout:
+                description: |-
+                  IdleTimeout is how long the update may produce no output at all before the operator
+                  gives up on it and marks it failed. It bounds the time a wedged update can hold one of
+                  the operator's reconcile workers, which is otherwise occupied for the whole operation.
+                  Because it measures silence rather than total duration, a slow but progressing update
+                  is never interrupted. Zero disables the timeout. Defaults to the operator's
+                  --update-idle-timeout.
+                type: string
               message:
                 description: Message (optional) to associate with the preview operation
                 type: string

--- a/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
+++ b/deploy/helm/pulumi-operator/crds/pulumi.com_stacks.yaml
@@ -1098,6 +1098,8 @@ spec:
                         type: boolean
                       expectNoChanges:
                         type: boolean
+                      idleTimeout:
+                        type: string
                       message:
                         type: string
                       parallel:
@@ -11729,6 +11731,8 @@ spec:
                         type: boolean
                       expectNoChanges:
                         type: boolean
+                      idleTimeout:
+                        type: string
                       message:
                         type: string
                       parallel:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -28,9 +28,21 @@ The current implementation explicitly emits the following metrics:
 In addition, we find tracking the following metrics emitted by the controller-runtime would be useful to track:
 
 1. `controller_runtime_active_workers{controller="stack-controller"}` - `gauge` that tracks the number of concurrent stacks being processed
-2. `controller_runtime_max_concurrent_reconciles{controller="stack-controller"}` - `gauge` that tracks the max concurrent stack reconciles configured. This defaults to 10 but can be controlled through `MAX_CONCURRENT_RECONCILES` environment variable passed to the Operator container.
+2. `controller_runtime_max_concurrent_reconciles{controller="stack-controller"}` - `gauge` that tracks the max concurrent stack reconciles configured. This defaults to 25 but can be controlled through the `--max-concurrent-reconciles` flag or the `MAX_CONCURRENT_RECONCILES` environment variable passed to the Operator container. The update controller can be sized separately with `--update-max-concurrent-reconciles` / `UPDATE_MAX_CONCURRENT_RECONCILES`, since its reconciles block for the duration of the Pulumi operation.
 3. `controller_runtime_reconcile_total{controller="stack-controller",result="error"}` - `counter` for errored reconciles
 4. `controller_runtime_reconcile_total{controller="stack-controller",result="requeue"}` - `counter` for requeued reconciles
+
+For the update controller specifically, watch the workqueue rather than CPU and memory. A reconcile there blocks for the whole Pulumi operation while the real work happens in the workspace pod, so a fully saturated operator looks idle by resource usage — only these distinguish the two:
+
+1. `controller_runtime_active_workers{controller="update-controller"}` - at `controller_runtime_max_concurrent_reconciles` the controller has no spare capacity
+2. `workqueue_depth{name="update-controller"}` - a persistently deep queue means updates are waiting for a worker, not running
+3. `workqueue_longest_running_processor_seconds{name="update-controller"}` - the age of the longest *actively running* reconcile
+
+Note what metric 3 cannot tell you. It reports only the longest reconcile currently on a worker, so it is blind to Updates stranded at `Progressing=True` whose reconcile already ended — for instance because the operator was killed mid-operation. Nor is a large value proof of a problem: legitimate updates can run for many hours, so age alone does not distinguish a healthy long update from a wedged one.
+
+To find stranded Updates, look at the objects rather than the metrics: list Updates whose `Progressing` condition is `True` and group them by `lastTransitionTime`. A cluster of Updates sharing one timestamp to the second is the signature of an operator restart that left them behind. Before deleting any of them, confirm the operation is really gone by checking that the workspace's `pulumi` **container** started *after* that transition — container start, not pod start, since a restarted container leaves `.status.startTime` on the pod unchanged.
+
+`--update-idle-timeout` bounds the separate case of a reconcile that is still running but whose update has stopped producing output.
 
 The next section walks through setting up `Kube-Prometheus-Stack` on an existing Kubernetes cluster and configuring metrics for the operator.
 

--- a/docs/stacks.md
+++ b/docs/stacks.md
@@ -2925,6 +2925,13 @@ with apply.
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>idleTimeout</b></td>
+        <td>string</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>message</b></td>
         <td>string</td>
         <td>
@@ -24740,6 +24747,13 @@ with apply.
       </tr><tr>
         <td><b>expectNoChanges</b></td>
         <td>boolean</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>idleTimeout</b></td>
+        <td>string</td>
         <td>
           <br/>
         </td>

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -99,6 +99,18 @@ occurrence of errors.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>idleTimeout</b></td>
+        <td>string</td>
+        <td>
+          IdleTimeout is how long the update may produce no output at all before the operator
+gives up on it and marks it failed. It bounds the time a wedged update can hold one of
+the operator's reconcile workers, which is otherwise occupied for the whole operation.
+Because it measures silence rather than total duration, a slow but progressing update
+is never interrupted. Zero disables the timeout. Defaults to the operator's
+--update-idle-timeout.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>message</b></td>
         <td>string</td>
         <td>

--- a/operator/api/auto/v1alpha1/update_types.go
+++ b/operator/api/auto/v1alpha1/update_types.go
@@ -44,6 +44,14 @@ type UpdateSpec struct {
 	// TTL for a completed update object.
 	// +optional
 	TtlAfterCompleted *metav1.Duration `json:"ttlAfterCompleted,omitempty"`
+	// IdleTimeout is how long the update may produce no output at all before the operator
+	// gives up on it and marks it failed. It bounds the time a wedged update can hold one of
+	// the operator's reconcile workers, which is otherwise occupied for the whole operation.
+	// Because it measures silence rather than total duration, a slow but progressing update
+	// is never interrupted. Zero disables the timeout. Defaults to the operator's
+	// --update-idle-timeout.
+	// +optional
+	IdleTimeout *metav1.Duration `json:"idleTimeout,omitempty"`
 	// Parallel is the number of resource operations to run in parallel at once
 	// (1 for no parallelism). Defaults to unbounded.
 	// +optional

--- a/operator/api/auto/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/api/auto/v1alpha1/zz_generated.deepcopy.go
@@ -363,6 +363,11 @@ func (in *UpdateSpec) DeepCopyInto(out *UpdateSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.IdleTimeout != nil {
+		in, out := &in.IdleTimeout, &out.IdleTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.Parallel != nil {
 		in, out := &in.Parallel, &out.Parallel
 		*out = new(int32)

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -15,9 +15,11 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -83,6 +85,12 @@ func main() {
 		leaderElectionRenewDeadline time.Duration
 		leaderElectionRetryPeriod   time.Duration
 		kubeAPITimeout              time.Duration
+
+		// Flags for configuring reconcile concurrency and update liveness.
+		maxConcurrentReconciles       int
+		updateMaxConcurrentReconciles int
+		updateIdleTimeout             time.Duration
+		gracefulShutdownTimeout       time.Duration
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metric endpoint binds to. "+
@@ -111,6 +119,25 @@ func main() {
 	flag.DurationVar(&kubeAPITimeout, "kube-api-timeout", 30*time.Second,
 		"Timeout for requests to the Kubernetes API server. "+
 			"Can also be set via KUBE_API_TIMEOUT environment variable.")
+	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 25,
+		"Maximum number of concurrent reconciles per controller. "+
+			"Can also be set via MAX_CONCURRENT_RECONCILES environment variable.")
+	flag.IntVar(&updateMaxConcurrentReconciles, "update-max-concurrent-reconciles", 0,
+		"Maximum number of concurrent reconciles for the update controller specifically, whose "+
+			"reconciles block for the duration of the Pulumi operation. 0 uses "+
+			"--max-concurrent-reconciles. Can also be set via "+
+			"UPDATE_MAX_CONCURRENT_RECONCILES environment variable.")
+	flag.DurationVar(&updateIdleTimeout, "update-idle-timeout", autocontroller.DefaultUpdateIdleTimeout,
+		"How long an update may produce no output before the operator abandons it and marks it "+
+			"failed, bounding how long a wedged update can hold a reconcile worker. Measures "+
+			"silence, not total duration, so a slow but progressing update is unaffected. "+
+			"0 disables it. Overridable per update via Update.spec.idleTimeout. "+
+			"Can also be set via UPDATE_IDLE_TIMEOUT environment variable.")
+	flag.DurationVar(&gracefulShutdownTimeout, "graceful-shutdown-timeout", 5*time.Minute,
+		"How long to allow in-flight reconciles to finish when shutting down. Should be no "+
+			"larger than the pod's terminationGracePeriodSeconds. Reconciles cut short here "+
+			"leave their Updates Progressing until the operator restarts and aborts them. "+
+			"Can also be set via GRACEFUL_SHUTDOWN_TIMEOUT_DURATION environment variable.")
 
 	// Configure Zap-based logging for klog/v2 and for the controller manager.
 	// Write to stdout by default.
@@ -171,34 +198,40 @@ func main() {
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 	}
 
-	// Override leader election timeouts from environment variables if set
-	if s, ok := os.LookupEnv("LEADER_ELECTION_LEASE_DURATION"); ok {
-		if d, err := time.ParseDuration(s); err == nil {
-			leaderElectionLeaseDuration = d
-		}
-	}
-	if s, ok := os.LookupEnv("LEADER_ELECTION_RENEW_DEADLINE"); ok {
-		if d, err := time.ParseDuration(s); err == nil {
-			leaderElectionRenewDeadline = d
-		}
-	}
-	if s, ok := os.LookupEnv("LEADER_ELECTION_RETRY_PERIOD"); ok {
-		if d, err := time.ParseDuration(s); err == nil {
-			leaderElectionRetryPeriod = d
-		}
-	}
-	if s, ok := os.LookupEnv("KUBE_API_TIMEOUT"); ok {
-		if d, err := time.ParseDuration(s); err == nil {
-			kubeAPITimeout = d
+	// Override from environment variables if set. A malformed value is fatal rather than
+	// ignored: silently falling back to the default leaves the operator running with settings
+	// the deployment did not ask for, which is very hard to notice after the fact. In
+	// particular, a bad MAX_CONCURRENT_RECONCILES used to yield 0, which controller-runtime
+	// treats as 1 -- a silent collapse from 25 workers to one, with nothing in the logs.
+	for _, err := range []error{
+		envDuration("LEADER_ELECTION_LEASE_DURATION", &leaderElectionLeaseDuration),
+		envDuration("LEADER_ELECTION_RENEW_DEADLINE", &leaderElectionRenewDeadline),
+		envDuration("LEADER_ELECTION_RETRY_PERIOD", &leaderElectionRetryPeriod),
+		envDuration("KUBE_API_TIMEOUT", &kubeAPITimeout),
+		envDuration("UPDATE_IDLE_TIMEOUT", &updateIdleTimeout),
+		envDuration("GRACEFUL_SHUTDOWN_TIMEOUT_DURATION", &gracefulShutdownTimeout),
+		envInt("MAX_CONCURRENT_RECONCILES", &maxConcurrentReconciles),
+		envInt("UPDATE_MAX_CONCURRENT_RECONCILES", &updateMaxConcurrentReconciles),
+	} {
+		if err != nil {
+			setupLog.Error(err, "invalid configuration")
+			os.Exit(1)
 		}
 	}
 
+	if err := validateConcurrency(maxConcurrentReconciles, updateMaxConcurrentReconciles, updateIdleTimeout); err != nil {
+		setupLog.Error(err, "invalid configuration")
+		os.Exit(1)
+	}
+
 	controllerOpts := config.Controller{
-		MaxConcurrentReconciles: 25,
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}
-	if s, ok := os.LookupEnv("MAX_CONCURRENT_RECONCILES"); ok {
-		controllerOpts.MaxConcurrentReconciles, _ = strconv.Atoi(s)
-	}
+	setupLog.Info("Configured controller concurrency",
+		"maxConcurrentReconciles", maxConcurrentReconciles,
+		"updateMaxConcurrentReconciles", cmp.Or(updateMaxConcurrentReconciles, maxConcurrentReconciles),
+		"updateIdleTimeout", updateIdleTimeout,
+	)
 
 	// Configure REST client with custom timeout
 	restConfig := ctrl.GetConfigOrDie()
@@ -227,6 +260,10 @@ func main() {
 		LeaseDuration:          &leaderElectionLeaseDuration,
 		RenewDeadline:          &leaderElectionRenewDeadline,
 		RetryPeriod:            &leaderElectionRetryPeriod,
+		// Give in-flight reconciles a chance to finish. An update controller reconcile runs for
+		// the length of its Pulumi operation, and one cut short leaves its Update Progressing
+		// until a restarted operator aborts it, so the 30s default is far too short here.
+		GracefulShutdownTimeout: &gracefulShutdownTimeout,
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
@@ -277,10 +314,12 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&autocontroller.UpdateReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		Recorder:          mgr.GetEventRecorderFor("update-controller"),
-		ConnectionManager: cm,
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		Recorder:                mgr.GetEventRecorderFor("update-controller"),
+		ConnectionManager:       cm,
+		MaxConcurrentReconciles: updateMaxConcurrentReconciles,
+		IdleTimeout:             updateIdleTimeout,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Update")
 		os.Exit(1)
@@ -385,6 +424,53 @@ func determineAdvAddr(addr string) string {
 		}
 	}
 	return net.JoinHostPort(host, port)
+}
+
+// validateConcurrency rejects settings that controller-runtime would otherwise accept and
+// quietly reinterpret. A non-positive MaxConcurrentReconciles becomes 1, which reads as an
+// unexplained throughput collapse rather than a configuration error.
+func validateConcurrency(maxConcurrentReconciles, updateMaxConcurrentReconciles int, updateIdleTimeout time.Duration) error {
+	if maxConcurrentReconciles <= 0 {
+		return fmt.Errorf("max-concurrent-reconciles must be greater than zero, got %d", maxConcurrentReconciles)
+	}
+	if updateMaxConcurrentReconciles < 0 {
+		return fmt.Errorf("update-max-concurrent-reconciles must not be negative, got %d", updateMaxConcurrentReconciles)
+	}
+	if updateIdleTimeout < 0 {
+		return fmt.Errorf("update-idle-timeout must not be negative, got %s", updateIdleTimeout)
+	}
+	return nil
+}
+
+// envDuration overrides target from an environment variable, reporting a malformed value rather
+// than ignoring it. Silently keeping the default would leave the operator running on settings
+// the deployment did not ask for, which is close to impossible to spot after the fact.
+func envDuration(envName string, target *time.Duration) error {
+	s, ok := os.LookupEnv(envName)
+	if !ok {
+		return nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("invalid duration in %s=%q: %w", envName, s, err)
+	}
+	*target = d
+	return nil
+}
+
+// envInt overrides target from an environment variable, reporting a malformed value rather than
+// ignoring it. See envDuration.
+func envInt(envName string, target *int) error {
+	s, ok := os.LookupEnv(envName)
+	if !ok {
+		return nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return fmt.Errorf("invalid integer in %s=%q: %w", envName, s, err)
+	}
+	*target = n
+	return nil
 }
 
 func envOrDefault(envName, defaultValue string) string {

--- a/operator/cmd/main_test.go
+++ b/operator/cmd/main_test.go
@@ -16,9 +16,113 @@ package main
 
 import (
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
+
+// TestEnvDuration and TestEnvInt cover the environment overrides that used to discard their
+// parse errors. A malformed MAX_CONCURRENT_RECONCILES silently became 0, which
+// controller-runtime treats as 1 -- a silent 25x throughput drop with nothing in the logs.
+// See https://github.com/pulumi/pulumi-kubernetes-operator/issues/1293.
+func TestEnvDuration(t *testing.T) {
+	const name = "TEST_DURATION"
+	tests := []struct {
+		name    string
+		set     bool
+		value   string
+		want    time.Duration
+		wantErr string
+	}{
+		{name: "unset leaves the default", want: time.Second},
+		{name: "valid value overrides", set: true, value: "5m", want: 5 * time.Minute},
+		{name: "zero is honored", set: true, value: "0s", want: 0},
+		{name: "malformed is an error", set: true, value: "5", want: time.Second, wantErr: `invalid duration in TEST_DURATION="5"`},
+		{name: "empty is an error", set: true, value: "", want: time.Second, wantErr: `invalid duration in TEST_DURATION=""`},
+		{name: "trailing space is an error", set: true, value: "5m ", want: time.Second, wantErr: "invalid duration"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv(name, tt.value)
+			}
+			got := time.Second
+			err := envDuration(name, &got)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got, "the target should be left alone on error")
+		})
+	}
+}
+
+func TestEnvInt(t *testing.T) {
+	const name = "TEST_INT"
+	tests := []struct {
+		name    string
+		set     bool
+		value   string
+		want    int
+		wantErr string
+	}{
+		{name: "unset leaves the default", want: 25},
+		{name: "valid value overrides", set: true, value: "50", want: 50},
+		{name: "zero is parsed, and rejected later by validateConcurrency", set: true, value: "0", want: 0},
+		{name: "malformed is an error", set: true, value: "abc", want: 25, wantErr: `invalid integer in TEST_INT="abc"`},
+		{name: "empty is an error", set: true, value: "", want: 25, wantErr: "invalid integer"},
+		{name: "trailing space is an error", set: true, value: "10 ", want: 25, wantErr: "invalid integer"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv(name, tt.value)
+			}
+			got := 25
+			err := envInt(name, &got)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got, "the target should be left alone on error")
+		})
+	}
+}
+
+func TestValidateConcurrency(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxRecon    int
+		updateRecon int
+		idle        time.Duration
+		wantErr     string
+	}{
+		{name: "defaults are valid", maxRecon: 25, updateRecon: 0, idle: 30 * time.Minute},
+		{name: "an explicit update budget is valid", maxRecon: 25, updateRecon: 10, idle: time.Minute},
+		{name: "a disabled idle timeout is valid", maxRecon: 1, updateRecon: 0, idle: 0},
+		{name: "zero reconciles is rejected", maxRecon: 0, wantErr: "max-concurrent-reconciles must be greater than zero"},
+		{name: "negative reconciles is rejected", maxRecon: -1, wantErr: "max-concurrent-reconciles must be greater than zero"},
+		{name: "a negative update budget is rejected", maxRecon: 25, updateRecon: -1, wantErr: "update-max-concurrent-reconciles must not be negative"},
+		{name: "a negative idle timeout is rejected", maxRecon: 25, idle: -time.Second, wantErr: "update-idle-timeout must not be negative"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConcurrency(tt.maxRecon, tt.updateRecon, tt.idle)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
 
 func TestDetermineAdvAddr(t *testing.T) {
 	const fakehostname = "fakehostname"

--- a/operator/config/crd/bases/auto.pulumi.com_updates.yaml
+++ b/operator/config/crd/bases/auto.pulumi.com_updates.yaml
@@ -77,6 +77,15 @@ spec:
               expectNoChanges:
                 description: Return an error if any changes occur during this update
                 type: boolean
+              idleTimeout:
+                description: |-
+                  IdleTimeout is how long the update may produce no output at all before the operator
+                  gives up on it and marks it failed. It bounds the time a wedged update can hold one of
+                  the operator's reconcile workers, which is otherwise occupied for the whole operation.
+                  Because it measures silence rather than total duration, a slow but progressing update
+                  is never interrupted. Zero disables the timeout. Defaults to the operator's
+                  --update-idle-timeout.
+                type: string
               message:
                 description: Message (optional) to associate with the preview operation
                 type: string

--- a/operator/config/crd/bases/pulumi.com_stacks.yaml
+++ b/operator/config/crd/bases/pulumi.com_stacks.yaml
@@ -1098,6 +1098,8 @@ spec:
                         type: boolean
                       expectNoChanges:
                         type: boolean
+                      idleTimeout:
+                        type: string
                       message:
                         type: string
                       parallel:
@@ -11729,6 +11731,8 @@ spec:
                         type: boolean
                       expectNoChanges:
                         type: boolean
+                      idleTimeout:
+                        type: string
                       message:
                         type: string
                       parallel:

--- a/operator/internal/apply/auto/v1alpha1/updatespec.go
+++ b/operator/internal/apply/auto/v1alpha1/updatespec.go
@@ -28,6 +28,7 @@ type UpdateSpecApplyConfiguration struct {
 	StackName         *string                  `json:"stackName,omitempty"`
 	Type              *autov1alpha1.UpdateType `json:"type,omitempty"`
 	TtlAfterCompleted *v1.Duration             `json:"ttlAfterCompleted,omitempty"`
+	IdleTimeout       *v1.Duration             `json:"idleTimeout,omitempty"`
 	Parallel          *int32                   `json:"parallel,omitempty"`
 	Message           *string                  `json:"message,omitempty"`
 	ExpectNoChanges   *bool                    `json:"expectNoChanges,omitempty"`
@@ -75,6 +76,14 @@ func (b *UpdateSpecApplyConfiguration) WithType(value autov1alpha1.UpdateType) *
 // If called multiple times, the TtlAfterCompleted field is set to the value of the last call.
 func (b *UpdateSpecApplyConfiguration) WithTtlAfterCompleted(value v1.Duration) *UpdateSpecApplyConfiguration {
 	b.TtlAfterCompleted = &value
+	return b
+}
+
+// WithIdleTimeout sets the IdleTimeout field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the IdleTimeout field is set to the value of the last call.
+func (b *UpdateSpecApplyConfiguration) WithIdleTimeout(value v1.Duration) *UpdateSpecApplyConfiguration {
+	b.IdleTimeout = &value
 	return b
 }
 

--- a/operator/internal/controller/auto/connect.go
+++ b/operator/internal/controller/auto/connect.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"time"
 
@@ -36,7 +37,46 @@ import (
 const (
 	pruneTokensOlderThan = 2 * time.Hour
 	maxRPCMessageSize    = 1024 * 1024 * 400
+
+	// TCP keepalive settings for connections to workspace pods. A Pulumi operation is a
+	// long-lived server-streaming RPC that can legitimately produce no traffic for a long
+	// time (a slow provider call, say), so a peer that silently vanishes -- a lost node, a
+	// partition -- is indistinguishable from a quiet one except by probing.
+	//
+	// net.Dialer already enables keepalive with a 15s idle, but leaves the probe interval and
+	// count to the system: on Linux that is 75s x 9, so noticing takes about 11 minutes. These
+	// values bring that down to about a minute. Note that this only bounds a *broken*
+	// connection; a workspace whose connection is healthy while its Pulumi operation is wedged
+	// is invisible at this layer, and is what the update controller's idle timeout is for.
+	//
+	// These are deliberately TCP-level rather than gRPC-level keepalives. gRPC pings are
+	// policed by the server's keepalive.EnforcementPolicy, whose default MinTime is 5
+	// minutes; pinging more often than a workspace's agent allows earns a GOAWAY with
+	// ENHANCE_YOUR_CALM and kills the stream. Since the agent image is pinned per Stack, the
+	// operator routinely talks to older agents whose policy it cannot know. TCP probes are
+	// invisible to HTTP/2, so they are safe against every agent version.
+	//
+	// A broken connection is detected after roughly workspaceKeepaliveIdle +
+	// workspaceKeepaliveInterval*workspaceKeepaliveCount.
+	workspaceKeepaliveIdle     = 30 * time.Second
+	workspaceKeepaliveInterval = 10 * time.Second
+	workspaceKeepaliveCount    = 3
 )
+
+// dialWorkspace establishes a TCP connection to a workspace pod with keepalive probes
+// enabled, so that losing the pod or the network surfaces as a stream error rather than an
+// indefinite block. See the workspaceKeepalive* constants.
+func dialWorkspace(ctx context.Context, addr string) (net.Conn, error) {
+	d := &net.Dialer{
+		KeepAliveConfig: net.KeepAliveConfig{
+			Enable:   true,
+			Idle:     workspaceKeepaliveIdle,
+			Interval: workspaceKeepaliveInterval,
+			Count:    workspaceKeepaliveCount,
+		},
+	}
+	return d.DialContext(ctx, "tcp", addr)
+}
 
 // ConnectionManager is responsible for managing connections to workspaces.
 type ConnectionManager struct {
@@ -77,6 +117,7 @@ func (cm *ConnectionManager) Connect(ctx context.Context, w *autov1alpha1.Worksp
 		addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithPerRPCCredentials(creds),
+		grpc.WithContextDialer(dialWorkspace),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxRPCMessageSize)))
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to workspace: %w", err)

--- a/operator/internal/controller/auto/connect_keepalive_unix_test.go
+++ b/operator/internal/controller/auto/connect_keepalive_unix_test.go
@@ -1,0 +1,57 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build unix
+
+package controller
+
+import (
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// assertKeepaliveTuned checks the probe interval and count on the socket.
+//
+// Deliberately not asserting SO_KEEPALIVE itself: net.Dialer turns keepalive on by default
+// (with a 15s idle), so that would pass no matter what this package does. The interval and
+// count are the parts that are not defaults -- on Linux the defaults are 75s and 9 probes,
+// giving ~11 minutes to notice a black-holed peer -- so they are what pins the change.
+func assertKeepaliveTuned(t *testing.T, conn *net.TCPConn) {
+	t.Helper()
+
+	raw, err := conn.SyscallConn()
+	require.NoError(t, err)
+
+	get := func(name int) int {
+		t.Helper()
+		var (
+			value  int
+			optErr error
+		)
+		require.NoError(t, raw.Control(func(fd uintptr) {
+			value, optErr = syscall.GetsockoptInt(int(fd), syscall.IPPROTO_TCP, name)
+		}))
+		require.NoError(t, optErr)
+		return value
+	}
+
+	assert.Equal(t, int(workspaceKeepaliveInterval.Seconds()), get(syscall.TCP_KEEPINTVL),
+		"probe interval should be the tuned value, not the system default")
+	assert.Equal(t, workspaceKeepaliveCount, get(syscall.TCP_KEEPCNT),
+		"probe count should be the tuned value, not the system default")
+}

--- a/operator/internal/controller/auto/connect_test.go
+++ b/operator/internal/controller/auto/connect_test.go
@@ -1,0 +1,85 @@
+// Copyright 2016-2025, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDialWorkspaceTunesKeepalive checks that connections to workspace pods carry tightened TCP
+// keepalive probes, so that a workspace lost to a node failure or partition is noticed in about
+// a minute rather than the ~11 minutes the system defaults allow. That bounds how long such a
+// peer can keep an update controller worker parked in Recv().
+// See https://github.com/pulumi/pulumi-kubernetes-operator/issues/1293.
+func TestDialWorkspaceTunesKeepalive(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lis.Close() })
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, err := lis.Accept()
+		if err != nil {
+			return
+		}
+		accepted <- c
+	}()
+
+	conn, err := dialWorkspace(t.Context(), lis.Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	tcpConn, ok := conn.(*net.TCPConn)
+	require.True(t, ok, "expected a TCP connection, got %T", conn)
+	assertKeepaliveTuned(t, tcpConn)
+
+	select {
+	case c := <-accepted:
+		_ = c.Close()
+	case <-time.After(5 * time.Second):
+		t.Fatal("the server never accepted the connection")
+	}
+}
+
+// TestWorkspaceKeepaliveBoundsDetection guards the intent of the keepalive constants: they must
+// bound how long a lost workspace can go unnoticed. A regression that disabled or greatly
+// relaxed them would reintroduce the indefinite block, so pin the resulting detection window.
+func TestWorkspaceKeepaliveBoundsDetection(t *testing.T) {
+	assert.Positive(t, workspaceKeepaliveIdle)
+	assert.Positive(t, workspaceKeepaliveInterval)
+	assert.Positive(t, workspaceKeepaliveCount)
+
+	detection := workspaceKeepaliveIdle +
+		workspaceKeepaliveInterval*time.Duration(workspaceKeepaliveCount)
+	assert.LessOrEqual(t, detection, 2*time.Minute,
+		"a dead workspace should be detected in minutes, not hours")
+}
+
+// TestDialWorkspaceHonorsContext checks that a dial is abandoned when its context is done, so
+// that Connect's own timeout still governs how long connecting may take.
+func TestDialWorkspaceHonorsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	// 203.0.113.0/24 is reserved for documentation, so this cannot connect.
+	_, err := dialWorkspace(ctx, "203.0.113.1:50051")
+	assert.ErrorIs(t, err, context.Canceled)
+}

--- a/operator/internal/controller/auto/update_controller.go
+++ b/operator/internal/controller/auto/update_controller.go
@@ -17,6 +17,7 @@ package controller
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -43,6 +44,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -69,7 +71,17 @@ const (
 	UpdateConditionReasonCanceled        = "Canceled"
 	UpdateConditionReasonUpdateFailed    = "UpdateFailed"
 	UpdateConditionReasonUpdateSucceeded = "UpdateSucceeded"
+	UpdateConditionReasonIdleTimeout     = "IdleTimeout"
+
+	// DefaultUpdateIdleTimeout is how long an update may produce no output before the operator
+	// abandons it. Generous, because it has to accommodate a single slow resource operation;
+	// its job is to bound a wedged worker, not to enforce a schedule.
+	DefaultUpdateIdleTimeout = 30 * time.Minute
 )
+
+// errIdleTimeout marks a stream that was abandoned for producing no output, distinguishing it
+// from a cancellation caused by the manager shutting down.
+var errIdleTimeout = errors.New("idle timeout exceeded")
 
 // UpdateReconciler reconciles a Update object
 type UpdateReconciler struct {
@@ -77,6 +89,16 @@ type UpdateReconciler struct {
 	Scheme            *runtime.Scheme
 	Recorder          record.EventRecorder
 	ConnectionManager *ConnectionManager
+
+	// MaxConcurrentReconciles bounds how many updates this controller runs at once. It is
+	// separate from the manager-wide default because a reconcile here blocks for the entire
+	// Pulumi operation, so this controller's budget must be sized against update concurrency
+	// rather than shared with controllers whose reconciles return promptly. Zero uses the
+	// manager default.
+	MaxConcurrentReconciles int
+
+	// IdleTimeout is the default for Update.spec.idleTimeout. Zero disables the timeout.
+	IdleTimeout time.Duration
 
 	// activeReconciles tracks Updates currently being reconciled by this
 	// process. Used by mapWorkspaceToUpdate to avoid re-enqueuing in-flight
@@ -111,6 +133,7 @@ func (r *UpdateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	defer r.activeReconciles.Delete(key)
 
 	rs := newReconcileSession(r.Client, r.Recorder, obj)
+	rs.idleTimeout = r.idleTimeoutFor(obj)
 
 	if rs.complete.Status == metav1.ConditionTrue {
 		// implement ttl for completed updates
@@ -249,6 +272,16 @@ func (r *UpdateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 }
 
+// idleTimeoutFor returns the idle timeout to apply to an update, preferring the value on the
+// object over the operator-wide default. A zero value on the object disables the watchdog for
+// that update rather than falling back to the default.
+func (r *UpdateReconciler) idleTimeoutFor(obj *autov1alpha1.Update) time.Duration {
+	if obj.Spec.IdleTimeout != nil {
+		return obj.Spec.IdleTimeout.Duration
+	}
+	return r.IdleTimeout
+}
+
 func isOrphaned(obj *autov1alpha1.Update) bool {
 	// an Update is considered orphaned if it has no managing controller.
 	return !controllerutil.HasControllerReference(obj)
@@ -290,6 +323,22 @@ type reconcileSession struct {
 	failed      *metav1.Condition
 	client      client.Client
 	recorder    record.EventRecorder
+
+	// idleTimeout bounds how long an operation's stream may be silent before it is abandoned.
+	// Zero disables the watchdog.
+	idleTimeout time.Duration
+}
+
+// beginOperation returns the context governing a streaming Pulumi operation, along with the
+// reader plumbing needed to abandon it if it goes silent.
+//
+// The returned context is a child of the reconcile context rather than the reconcile context
+// itself, so that abandoning the operation leaves the caller able to write the status that
+// records the outcome. Cancelling the reconcile context instead -- as happens on manager
+// shutdown -- deliberately fails that write too, leaving the Update Progressing so the
+// restarted operator's guard can mark it Aborted.
+func (u *reconcileSession) beginOperation(ctx context.Context) (context.Context, context.CancelCauseFunc) {
+	return context.WithCancelCause(ctx)
 }
 
 // newReconcileSession creates a new reconcileSession.
@@ -413,14 +462,17 @@ func (u *reconcileSession) Preview(ctx context.Context, obj *autov1alpha1.Update
 	}
 
 	l.Info("Executing preview operation", "request", autoReq)
-	res, err := client.Preview(ctx, autoReq, grpc.WaitForReady(true))
+	opCtx, cancelOp := u.beginOperation(ctx)
+	defer cancelOp(nil)
+	res, err := client.Preview(opCtx, autoReq, grpc.WaitForReady(true))
 	if err != nil {
 		emitEvent(u.recorder, obj, autov1alpha1.UpdateFailedEvent(), "Failed to preview stack %q", obj.Spec.StackName)
 		return ctrl.Result{}, fmt.Errorf("failed request to workspace: %w", err)
 	}
 	defer func() { _ = res.CloseSend() }()
 
-	reader := streamReader[agentpb.PreviewStream]{receiver: res, l: l, u: u, obj: obj}
+	reader := streamReader[agentpb.PreviewStream]{receiver: res, l: l, u: u, obj: obj,
+		opCtx: opCtx, cancelOp: cancelOp, idleTimeout: u.idleTimeout}
 	_, err = reader.Result()
 	if err != nil {
 		// Update the status/conditions.
@@ -461,14 +513,17 @@ func (u *reconcileSession) Update(ctx context.Context, obj *autov1alpha1.Update,
 	}
 
 	l.Info("Executing update operation", "request", autoReq)
-	res, err := client.Up(ctx, autoReq, grpc.WaitForReady(true))
+	opCtx, cancelOp := u.beginOperation(ctx)
+	defer cancelOp(nil)
+	res, err := client.Up(opCtx, autoReq, grpc.WaitForReady(true))
 	if err != nil {
 		emitEvent(u.recorder, obj, autov1alpha1.UpdateFailedEvent(), "Failed to update stack %q", obj.Spec.StackName)
 		return ctrl.Result{}, fmt.Errorf("failed request to workspace: %w", err)
 	}
 	defer func() { _ = res.CloseSend() }()
 
-	reader := streamReader[agentpb.UpStream]{receiver: res, l: l, u: u, obj: obj}
+	reader := streamReader[agentpb.UpStream]{receiver: res, l: l, u: u, obj: obj,
+		opCtx: opCtx, cancelOp: cancelOp, idleTimeout: u.idleTimeout}
 	result, err := reader.Result()
 	if err != nil {
 		// Update the status/conditions.
@@ -511,14 +566,17 @@ func (u *reconcileSession) Refresh(ctx context.Context, obj *autov1alpha1.Update
 	}
 
 	l.Info("Executing refresh operation", "request", autoReq)
-	res, err := client.Refresh(ctx, autoReq, grpc.WaitForReady(true))
+	opCtx, cancelOp := u.beginOperation(ctx)
+	defer cancelOp(nil)
+	res, err := client.Refresh(opCtx, autoReq, grpc.WaitForReady(true))
 	if err != nil {
 		emitEvent(u.recorder, obj, autov1alpha1.UpdateFailedEvent(), "Failed to refresh stack %q", obj.Spec.StackName)
 		return ctrl.Result{}, fmt.Errorf("failed request to workspace: %w", err)
 	}
 	defer func() { _ = res.CloseSend() }()
 
-	reader := streamReader[agentpb.RefreshStream]{receiver: res, l: l, u: u, obj: obj}
+	reader := streamReader[agentpb.RefreshStream]{receiver: res, l: l, u: u, obj: obj,
+		opCtx: opCtx, cancelOp: cancelOp, idleTimeout: u.idleTimeout}
 	_, err = reader.Result()
 	if err != nil {
 		// Update the status/conditions.
@@ -551,14 +609,17 @@ func (u *reconcileSession) Destroy(ctx context.Context, obj *autov1alpha1.Update
 	}
 
 	l.Info("Executing destroy operation", "request", autoReq)
-	res, err := client.Destroy(ctx, autoReq, grpc.WaitForReady(true))
+	opCtx, cancelOp := u.beginOperation(ctx)
+	defer cancelOp(nil)
+	res, err := client.Destroy(opCtx, autoReq, grpc.WaitForReady(true))
 	if err != nil {
 		emitEvent(u.recorder, obj, autov1alpha1.UpdateFailedEvent(), "Failed to destroy stack %q", obj.Spec.StackName)
 		return ctrl.Result{}, fmt.Errorf("failed request to workspace: %w", err)
 	}
 	defer func() { _ = res.CloseSend() }()
 
-	reader := streamReader[agentpb.DestroyStream]{receiver: res, l: l, u: u, obj: obj}
+	reader := streamReader[agentpb.DestroyStream]{receiver: res, l: l, u: u, obj: obj,
+		opCtx: opCtx, cancelOp: cancelOp, idleTimeout: u.idleTimeout}
 	_, err = reader.Result()
 	if err != nil {
 		// Update the status/conditions.
@@ -618,8 +679,17 @@ func (r *UpdateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
+	// A reconcile here occupies its worker for the whole Pulumi operation, so give this
+	// controller a budget of its own rather than having long-running updates crowd out the
+	// prompt reconciles of the stack and workspace controllers.
+	opts := controller.Options{}
+	if r.MaxConcurrentReconciles > 0 {
+		opts.MaxConcurrentReconciles = r.MaxConcurrentReconciles
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("update-controller").
+		WithOptions(opts).
 		For(&autov1alpha1.Update{}, builder.WithPredicates(predicate.Or(
 			predicate.GenerationChangedPredicate{},
 			OwnerReferencesChangedPredicate{},
@@ -730,6 +800,15 @@ type streamReader[T stream] struct {
 	obj      *autov1alpha1.Update
 	u        *reconcileSession
 	l        logr.Logger
+
+	// opCtx is the context governing the streaming RPC, and cancelOp cancels it. They are
+	// scoped to the operation rather than to the reconcile, so that abandoning a wedged stream
+	// does not also cancel the status write that records the outcome.
+	opCtx    context.Context
+	cancelOp context.CancelCauseFunc
+	// idleTimeout bounds how long the stream may be silent before it is abandoned. Zero
+	// disables the watchdog.
+	idleTimeout time.Duration
 }
 
 // Recv reads one message from the stream which may or may not contain a
@@ -748,12 +827,35 @@ func (s streamReader[T]) Result() (result, error) {
 	var res result
 
 	startTime := time.Now()
+
+	// Abandon the stream if it goes silent for too long. Without this the reconcile can block
+	// in Recv() indefinitely -- for instance when the agent is alive but wedged inside a
+	// provider call -- holding one of MaxConcurrentReconciles workers for the rest of the
+	// process's life. The timer is reset on every message, so a slow but talkative update is
+	// never interrupted.
+	var idle *time.Timer
+	if s.idleTimeout > 0 && s.cancelOp != nil {
+		idle = time.AfterFunc(s.idleTimeout, func() {
+			s.cancelOp(errIdleTimeout)
+		})
+		defer idle.Stop()
+	}
+
 	for {
 		stream, err := s.Recv()
+		if idle != nil {
+			idle.Reset(s.idleTimeout)
+		}
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
+			if s.opCtx != nil && errors.Is(context.Cause(s.opCtx), errIdleTimeout) {
+				s.l.Error(err, "no output from the update within the idle timeout; abandoning it",
+					"idleTimeout", s.idleTimeout)
+				s.setStatusBlockFromIdleTimeout()
+				return nil, fmt.Errorf("no output from the update for %s: %w", s.idleTimeout, errIdleTimeout)
+			}
 			s.l.Error(err, "Unexpected error from response stream")
 			s.setStatusBlockFromGRPCErr(err)
 			return nil, err
@@ -803,6 +905,22 @@ func (s streamReader[T]) Result() (result, error) {
 	}
 
 	return res, fmt.Errorf("didn't receive a result")
+}
+
+// setStatusBlockFromIdleTimeout marks the Update terminally failed because it stopped
+// producing output. This must be terminal: leaving it Progressing would have the owning Stack
+// wait on an update that nothing will ever complete.
+func (s streamReader[T]) setStatusBlockFromIdleTimeout() {
+	s.obj.Status.Message = fmt.Sprintf(
+		"The update produced no output for %s and was abandoned. "+
+			"The Pulumi operation may still be running in the workspace pod.", s.idleTimeout)
+	s.u.progressing.Status = metav1.ConditionFalse
+	s.u.progressing.Reason = UpdateConditionReasonComplete
+	s.u.complete.Status = metav1.ConditionTrue
+	s.u.complete.Reason = UpdateConditionReasonUpdated
+	s.u.failed.Status = metav1.ConditionTrue
+	s.u.failed.Reason = UpdateConditionReasonIdleTimeout
+	s.u.failed.Message = ""
 }
 
 // setStatusBlockFromGRPCErr sets the Update object status blocks based on the result of a gRPC error.

--- a/operator/internal/controller/auto/update_controller_test.go
+++ b/operator/internal/controller/auto/update_controller_test.go
@@ -459,6 +459,123 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+// TestUpdateIdleTimeout proves that a stream which stops producing output is abandoned rather
+// than blocking the reconcile forever, and -- crucially -- that the terminal status still
+// reaches the API server. Cancelling the reconcile context to stop the stream would also kill
+// that write, leaving the Update Progressing and its worker slot effectively lost.
+// See https://github.com/pulumi/pulumi-kubernetes-operator/issues/1293.
+func TestUpdateIdleTimeout(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+	scheme.Scheme.AddKnownTypes(
+		schema.GroupVersion{Group: "auto.pulumi.com", Version: "v1alpha1"},
+		&autov1alpha1.Update{},
+	)
+
+	obj := autov1alpha1.Update{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "uid"}}
+	kclient := fake.NewClientBuilder().WithObjects(&obj).WithStatusSubresource(&obj).Build()
+	recorder := record.NewFakeRecorder(10)
+	rs := newReconcileSession(kclient, recorder, &obj)
+	rs.idleTimeout = 50 * time.Millisecond
+
+	ctrl := gomock.NewController(t)
+	upper := NewMockupper(ctrl)
+	recver := NewMockrecver[agentpb.UpStream](ctrl)
+
+	// A silent agent: the stream is open and healthy, but nothing ever arrives. Recv unblocks
+	// only when the operation's context is cancelled, which is what the watchdog does.
+	var opCtx context.Context
+	upper.EXPECT().
+		Up(gomock.Any(), protoMatcher{&agentpb.UpRequest{}}, grpc.WaitForReady(true)).
+		DoAndReturn(func(c context.Context, _ *agentpb.UpRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[agentpb.UpStream], error) {
+			opCtx = c
+			return recver, nil
+		})
+	recver.EXPECT().Recv().DoAndReturn(func() (*agentpb.UpStream, error) {
+		<-opCtx.Done()
+		return nil, status.FromContextError(opCtx.Err()).Err()
+	})
+	recver.EXPECT().CloseSend().Return(nil).AnyTimes()
+
+	_, err := rs.Update(ctx, &obj, upper, NewMockcreator(ctrl))
+
+	assert.ErrorContains(t, err, "no output from the update for 50ms")
+	assert.ErrorIs(t, err, errIdleTimeout)
+	g.Expect(recorder.Events).To(Receive(matchEvent(string(autov1alpha1.UpdateFailed))))
+
+	// The terminal status must have reached the API server despite the cancellation.
+	var res autov1alpha1.Update
+	require.NoError(t, kclient.Get(ctx, types.NamespacedName{Name: obj.Name}, &res))
+	g.Expect(meta.IsStatusConditionTrue(res.Status.Conditions, UpdateConditionTypeComplete)).To(BeTrue())
+	g.Expect(meta.IsStatusConditionTrue(res.Status.Conditions, UpdateConditionTypeProgressing)).To(BeFalse())
+	failed := meta.FindStatusCondition(res.Status.Conditions, UpdateConditionTypeFailed)
+	g.Expect(failed).NotTo(BeNil())
+	g.Expect(failed.Status).To(Equal(metav1.ConditionTrue))
+	g.Expect(failed.Reason).To(Equal(UpdateConditionReasonIdleTimeout))
+	g.Expect(res.Status.Message).To(ContainSubstring("produced no output"))
+}
+
+// TestUpdateIdleTimeoutDisabled proves the watchdog is opt-out, and that a zero timeout does
+// not abandon a stream immediately.
+func TestUpdateIdleTimeoutDisabled(t *testing.T) {
+	scheme.Scheme.AddKnownTypes(
+		schema.GroupVersion{Group: "auto.pulumi.com", Version: "v1alpha1"},
+		&autov1alpha1.Update{},
+	)
+
+	obj := autov1alpha1.Update{ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "uid"}}
+	kclient := fake.NewClientBuilder().WithObjects(&obj).WithStatusSubresource(&obj).Build()
+	rs := newReconcileSession(kclient, record.NewFakeRecorder(10), &obj)
+	rs.idleTimeout = 0
+
+	ctrl := gomock.NewController(t)
+	upper := NewMockupper(ctrl)
+	recver := NewMockrecver[agentpb.UpStream](ctrl)
+
+	result := &agentpb.UpStream_Result{Result: &agentpb.UpResult{
+		Summary: &agentpb.UpdateSummary{Result: "succeeded"},
+	}}
+	gomock.InOrder(
+		upper.EXPECT().
+			Up(gomock.Any(), protoMatcher{&agentpb.UpRequest{}}, grpc.WaitForReady(true)).
+			Return(recver, nil),
+		// A gap longer than any plausible watchdog, to show nothing is armed.
+		recver.EXPECT().Recv().DoAndReturn(func() (*agentpb.UpStream, error) {
+			time.Sleep(100 * time.Millisecond)
+			return &agentpb.UpStream{Response: result}, nil
+		}),
+		recver.EXPECT().CloseSend().Return(nil),
+	)
+	c := NewMockcreator(ctrl)
+	c.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	_, err := rs.Update(t.Context(), &obj, upper, c)
+	assert.NoError(t, err)
+}
+
+// TestIdleTimeoutFor checks the precedence between the per-Update setting and the
+// operator-wide default, including that an explicit zero disables the watchdog.
+func TestIdleTimeoutFor(t *testing.T) {
+	tests := []struct {
+		name string
+		def  time.Duration
+		spec *metav1.Duration
+		want time.Duration
+	}{
+		{name: "falls back to the operator default", def: 30 * time.Minute, want: 30 * time.Minute},
+		{name: "the object overrides the default", def: 30 * time.Minute, spec: &metav1.Duration{Duration: time.Minute}, want: time.Minute},
+		{name: "an explicit zero disables it", def: 30 * time.Minute, spec: &metav1.Duration{}, want: 0},
+		{name: "disabled by default", def: 0, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &UpdateReconciler{IdleTimeout: tt.def}
+			obj := &autov1alpha1.Update{Spec: autov1alpha1.UpdateSpec{IdleTimeout: tt.spec}}
+			assert.Equal(t, tt.want, r.idleTimeoutFor(obj))
+		})
+	}
+}
+
 type protoMatcher struct {
 	proto.Message
 }


### PR DESCRIPTION
### Proposed changes

An update controller reconcile blocks for the entire Pulumi operation, so each one occupies a `MaxConcurrentReconciles` slot for as long as that operation runs. Nothing bounded it: the reconcile context has no deadline (the only `context.WithTimeout` covers `Connect`), all four operation RPCs use `grpc.WaitForReady(true)`, and an agent that is alive but wedged inside a provider call keeps its connection perfectly healthy while never sending another message — so `Recv()` blocks indefinitely. Because the reconcile never returns, `Progressing=True` is never revised and the deferred `activeReconciles` cleanup never runs, so `mapWorkspaceToUpdate` also declines to re-enqueue it.

#### Idle timeout on the operation stream

New `--update-idle-timeout` (default 30m), overridable per update via `Update.spec.idleTimeout`. Because `applyUpdateTemplate` merge-patches the whole Update, this is reachable from a Stack through `spec.updateTemplate.spec.idleTimeout` with no Stack-side plumbing.

It measures **silence rather than total duration** and is reset on every message, so a slow but progressing update is never interrupted — which matters given #1293 reports legitimate runs reaching 2h22m and 13.8h. `0` disables it.

The operation runs on a context *derived from* the reconcile's rather than the reconcile context itself. That distinction is the point: `setStatusBlockFromGRPCErr` sets `Complete=True` in memory and the caller then persists it with `updateStatus(ctx, obj)`. Cancelling the reconcile context to stop the stream would fail that write, leaving the Update `Progressing` forever — the very state being fixed. When the *reconcile* context is cancelled instead, as on manager shutdown, the write is skipped deliberately so the restarted operator's existing `Progressing` guard marks it `Aborted`.

#### Tightened TCP keepalive to workspace pods

Worth being precise about what this does and does not buy, because my first reading of the problem was wrong. `net.Dialer` **already** enables keepalive with a 15s idle, so these connections were never unprobed — I verified `SO_KEEPALIVE=1` and a 15s idle on a plain `(&net.Dialer{}).Dial`. What the defaults leave to the system is the probe interval and count: 75s × 9 on Linux, so a black-holed peer takes roughly 11 minutes to notice. This brings that to about a minute.

So it is hardening, not the fix — a lost node or partition is bounded sooner. It cannot see a connection that is healthy while the operation is wedged; that is what the idle timeout is for. It also benefits the workspace controller, which has the same unbounded-RPC exposure over the same dial path.

Deliberately TCP-level rather than gRPC-level. gRPC pings are policed by the server's `keepalive.EnforcementPolicy`, whose default `MinTime` is 5 minutes; since the agent image is pinned per Stack, the operator routinely talks to older agents whose policy it cannot know, and exceeding it earns a `GOAWAY / ENHANCE_YOUR_CALM` that would kill healthy long-running updates. TCP probes are invisible to HTTP/2, so they are safe against every agent version ever shipped.

#### Agent-side server keepalive

`keepalive.ServerParameters` on the agent, so it notices a departed operator, closes the transport, and lets the orphaned operation unwind via the existing `Cancel()` path. Server-initiated pings are not subject to any enforcement policy, so this needs no client cooperation. No `EnforcementPolicy` is set, on purpose: tightening its `MinTime` would let a new agent reject pings from a client behaving correctly for the default policy it was written against.

#### A separate worker budget for the update controller

`MaxConcurrentReconciles` was set once, manager-wide. The update controller is the only one whose reconciles block for hours, so sharing a pool means long operations crowd out the stack and workspace controllers — and queue the update controller's own *cheap* terminal transitions (`deleting → Canceled`) behind hour-long ones. That priority inversion is why a deleted Update could sit in `Terminating` unable to reach `Complete`, which is what the finalizer needs.

New `--update-max-concurrent-reconciles` (`0` = use the shared value).

#### Honour `GRACEFUL_SHUTDOWN_TIMEOUT_DURATION`

It is set to `5m` in `deploy/operator_template.yaml`, and read nowhere — so shutdown used controller-runtime's 30s default and cut short exactly the in-flight updates the pod's 300s `terminationGracePeriodSeconds` was sized to allow. Now wired, with a matching flag.

#### Tuning-surface fixes called out in the issue

```go
controllerOpts.MaxConcurrentReconciles, _ = strconv.Atoi(s)
```

The discarded error made a malformed `MAX_CONCURRENT_RECONCILES` silently `0`, which controller-runtime treats as **1** — a silent drop from 25 workers to one with nothing in the logs. Adds `--max-concurrent-reconciles`, rejects non-positive values, and applies the same non-silent parsing to the adjacent `LEADER_ELECTION_*` / `KUBE_API_TIMEOUT` overrides. Also drops a misleading empty `controller.Options{}` in the stack controller's setup.

#### Docs

`docs/metrics.md` gains a section on reading the update controller's workqueue, since resource usage cannot distinguish idle from saturated here. Per the issue's own correction, it states plainly what `workqueue_longest_running_processor_seconds` **cannot** show — it tracks only the longest actively-running reconcile, so it is blind to Updates stranded by a killed operator, and a large value is not proof of a problem — and gives the detection method that actually worked: group `Progressing=True` Updates by `lastTransitionTime`, and gate any deletion on the workspace's `pulumi` **container** start time, not the pod's. Also corrects the stated `MaxConcurrentReconciles` default from 10 to 25.

### Testing

- `TestUpdateIdleTimeout` — a silent stream is abandoned **and the terminal status actually reaches the API server** (the point of the derived context); asserts `Complete=True`, `Failed=True / IdleTimeout`.
- `TestUpdateIdleTimeoutDisabled` — a zero timeout arms nothing, and a long gap is not cut off.
- `TestIdleTimeoutFor` — precedence between the per-Update value and the operator default, including that an explicit zero disables rather than falls back.
- `connect_test.go` — the dialer applies the tuned probe interval and count, read back off the socket. Note it asserts the *tuned* values rather than `SO_KEEPALIVE`, because that is on by default and would pass regardless; I checked the test fails when the tuning is removed.
- `main_test.go` — table tests over valid / malformed / empty / zero / negative for the env overrides and the concurrency validation.

`make test` (operator + agent) and `golangci-lint` are clean, with no codegen drift. `make test-e2e` has **not** been run, and the failure mode has not been reproduced end-to-end against a live cluster.

### Related issues

Fixes #1293. The `Terminating`-with-finalizer half of that issue is handled in #1295, which touches the same stack-controller function as its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
