### PR TITLE
Skip pulumi install for projects that run a prebuilt binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## Unreleased
 
+- Skip `pulumi install` for a project that runs a prebuilt binary (`runtime.options.binary`) [#1297](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1297)
+
 ## 2.9.0 (2026-07-29)
 
 - Add `serviceTemplate` to the Workspace spec, allowing custom annotations and labels on the headless Service that fronts a workspace's pods; settable from a Stack via `spec.workspaceTemplate.spec.serviceTemplate.metadata` [#1280](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1280)

--- a/agent/cmd/serve.go
+++ b/agent/cmd/serve.go
@@ -151,7 +151,7 @@ var serveCmd = &cobra.Command{
 		log.Infow("opened a local workspace", "workspace", workDir,
 			"project", proj.Name, "runtime", proj.Runtime.Name())
 
-		if !_skipInstall {
+		if !_skipInstall && !server.HasPrebuiltBinary(proj) {
 			plog := zap.L().Named("pulumi")
 			stdout := &zapio.Writer{Log: plog, Level: zap.InfoLevel}
 			defer stdout.Close()

--- a/agent/pkg/server/server.go
+++ b/agent/pkg/server/server.go
@@ -48,6 +48,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 var _userAgent = fmt.Sprintf("pulumi-kubernetes-operator/%s", version.Version)
@@ -554,6 +555,17 @@ func (s *Server) AddEnvironments(ctx context.Context, in *pb.AddEnvironmentsRequ
 }
 
 func (s *Server) Install(ctx context.Context, in *pb.InstallRequest) (*pb.InstallResult, error) {
+	proj, err := s.ws.ProjectSettings(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Aborted, "unable to load project: %s", err)
+	}
+
+	if HasPrebuiltBinary(proj) {
+		s.log.Infow("skipping installation; the project runs a prebuilt binary",
+			"project", proj.Name, "runtime", proj.Runtime.Name())
+		return &pb.InstallResult{}, nil
+	}
+
 	stdout := &zapio.Writer{Log: s.plog, Level: zap.InfoLevel}
 	defer stdout.Close()
 	stderr := &zapio.Writer{Log: s.plog, Level: zap.WarnLevel}
@@ -572,6 +584,17 @@ func (s *Server) Install(ctx context.Context, in *pb.InstallRequest) (*pb.Instal
 
 	resp := &pb.InstallResult{}
 	return resp, nil
+}
+
+// HasPrebuiltBinary reports whether the project runs an already-compiled program, declared as
+// `runtime.options.binary` in Pulumi.yaml. Such a program has nothing to install, and installing
+// anyway requires a language toolchain the workspace does not otherwise need.
+func HasPrebuiltBinary(proj *workspace.Project) bool {
+	if proj == nil {
+		return false
+	}
+	binary, ok := proj.Runtime.Options()["binary"].(string)
+	return ok && binary != ""
 }
 
 // Preview implements proto.AutomationServiceServer.

--- a/agent/pkg/server/server_test.go
+++ b/agent/pkg/server/server_test.go
@@ -902,6 +902,11 @@ func TestInstall(t *testing.T) {
 			req:        &pb.InstallRequest{},
 			wantErr:    HasStatusCode(codes.Aborted, gomega.ContainSubstring("go.mod file not found")),
 		},
+		{
+			name:       "prebuilt",
+			projectDir: "./testdata/prebuilt",
+			req:        &pb.InstallRequest{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -919,6 +924,37 @@ func TestInstall(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHasPrebuiltBinary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		options map[string]any
+		want    bool
+	}{
+		{name: "no options", options: nil},
+		{name: "unrelated options", options: map[string]any{"buildTarget": "./bin"}},
+		{name: "binary set", options: map[string]any{"binary": "./app"}, want: true},
+		{name: "binary empty", options: map[string]any{"binary": ""}},
+		{name: "binary not a string", options: map[string]any{"binary": true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			proj := &workspace.Project{
+				Name:    "test",
+				Runtime: workspace.NewProjectRuntimeInfo("go", tt.options),
+			}
+			assert.Equal(t, tt.want, HasPrebuiltBinary(proj))
+		})
+	}
+
+	t.Run("nil project", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, HasPrebuiltBinary(nil))
+	})
 }
 
 func TestUp(t *testing.T) {

--- a/agent/pkg/server/testdata/prebuilt/Pulumi.yaml
+++ b/agent/pkg/server/testdata/prebuilt/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: prebuilt
+runtime:
+  name: go
+  options:
+    binary: ./app
+description: A project that runs a prebuilt binary and lacks a go.mod


### PR DESCRIPTION
Fixes #1297.

Adds detection of `runtime.options.binary` being set and skips calling the install RPC accordingly.

Includes tests.

