### PR TITLE
Don't run pulumi install on project-info workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## Unreleased
 
 - Skip `pulumi install` for a project that runs a prebuilt binary (`runtime.options.binary`) [#1297](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1297)
+- Don't run `pulumi install` on a workspace bootstrapped from project info [#1299](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1299)
 
 ## 2.9.0 (2026-07-29)
 

--- a/operator/internal/controller/auto/workspace_controller.go
+++ b/operator/internal/controller/auto/workspace_controller.go
@@ -314,28 +314,32 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 		}
 
-		l.Info("Running pulumi install")
-		ready.Status = metav1.ConditionFalse
-		ready.Reason = "Installing"
-		ready.Message = "Installing packages and plugins required by the program"
-		if err := updateStatus(); err != nil {
-			return ctrl.Result{}, err
-		}
-		_, err = wc.Install(ctx, &agentpb.InstallRequest{})
-		if err != nil {
-			l.Error(err, "unable to install; marking workspace as stalled")
-			emitEvent(r.Recorder, w, autov1alpha1.InstallationFailureEvent(), err.Error())
+		if w.Spec.ProjectInfo != nil {
+			l.Info("Skipping pulumi install; the workspace has no program")
+		} else {
+			l.Info("Running pulumi install")
 			ready.Status = metav1.ConditionFalse
-			ready.Reason = "InstallationFailed"
-			ready.Message = err.Error()
-			meta.SetStatusCondition(&w.Status.Conditions, metav1.Condition{
-				Type:               autov1alpha1.WorkspaceStalled,
-				Status:             metav1.ConditionTrue,
-				Reason:             "InstallationFailed",
-				Message:            err.Error(),
-				ObservedGeneration: w.Generation,
-			})
-			return ctrl.Result{}, updateStatus()
+			ready.Reason = "Installing"
+			ready.Message = "Installing packages and plugins required by the program"
+			if err := updateStatus(); err != nil {
+				return ctrl.Result{}, err
+			}
+			_, err = wc.Install(ctx, &agentpb.InstallRequest{})
+			if err != nil {
+				l.Error(err, "unable to install; marking workspace as stalled")
+				emitEvent(r.Recorder, w, autov1alpha1.InstallationFailureEvent(), err.Error())
+				ready.Status = metav1.ConditionFalse
+				ready.Reason = "InstallationFailed"
+				ready.Message = err.Error()
+				meta.SetStatusCondition(&w.Status.Conditions, metav1.Condition{
+					Type:               autov1alpha1.WorkspaceStalled,
+					Status:             metav1.ConditionTrue,
+					Reason:             "InstallationFailed",
+					Message:            err.Error(),
+					ObservedGeneration: w.Generation,
+				})
+				return ctrl.Result{}, updateStatus()
+			}
 		}
 
 		l.Info("Creating Pulumi stack(s)")

--- a/operator/internal/controller/auto/workspace_controller_test.go
+++ b/operator/internal/controller/auto/workspace_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -55,6 +56,7 @@ import (
 
 const (
 	TestFinalizer = "test.pulumi.com/finalizer"
+	testRevision  = "test-rev"
 )
 
 var (
@@ -625,6 +627,7 @@ type mockAutomationServer struct {
 	pulumiVersion  string
 	selectStackErr error
 	installErr     error
+	installCalls   atomic.Int32
 }
 
 func (s *mockAutomationServer) PulumiVersion(_ context.Context, _ *agentpb.PulumiVersionRequest) (*agentpb.PulumiVersionResult, error) {
@@ -632,6 +635,7 @@ func (s *mockAutomationServer) PulumiVersion(_ context.Context, _ *agentpb.Pulum
 }
 
 func (s *mockAutomationServer) Install(_ context.Context, _ *agentpb.InstallRequest) (*agentpb.InstallResult, error) {
+	s.installCalls.Add(1)
 	if s.installErr != nil {
 		return nil, s.installErr
 	}
@@ -755,9 +759,9 @@ func TestWorkspaceInitializationStalled(t *testing.T) {
 			sts.Status.Replicas = 1
 			sts.Status.ReadyReplicas = 1
 			sts.Status.AvailableReplicas = 1
-			sts.Status.CurrentRevision = "test-rev"
+			sts.Status.CurrentRevision = testRevision
 			sts.Status.CurrentReplicas = 1
-			sts.Status.UpdateRevision = "test-rev"
+			sts.Status.UpdateRevision = testRevision
 			sts.Status.UpdatedReplicas = 1
 			require.NoError(t, k8sclient.Status().Update(ctx, sts))
 
@@ -767,7 +771,7 @@ func TestWorkspaceInitializationStalled(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      podName,
 					Namespace: "default",
-					Labels:    map[string]string{"controller-revision-hash": "test-rev"},
+					Labels:    map[string]string{"controller-revision-hash": testRevision},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -800,6 +804,121 @@ func TestWorkspaceInitializationStalled(t *testing.T) {
 			podCheck := &corev1.Pod{}
 			require.NoError(t, k8sclient.Get(ctx, types.NamespacedName{Name: podName, Namespace: "default"}, podCheck))
 			assert.Nil(t, podCheck.DeletionTimestamp, "pod should not be marked for deletion")
+		})
+	}
+}
+
+func TestWorkspaceSkipInstall(t *testing.T) {
+	testScheme := scheme.Scheme
+	require.NoError(t, autov1alpha1.AddToScheme(testScheme))
+
+	env := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "config", "crd", "bases"),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := env.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = env.Stop() })
+
+	k8sclient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name             string
+		projectInfo      *autov1alpha1.ProjectInfoSource
+		wantInstallCalls int32
+	}{
+		{
+			name:             "a source-backed workspace is installed",
+			wantInstallCalls: 1,
+		},
+		{
+			name:             "a project-info workspace is not installed",
+			projectInfo:      &autov1alpha1.ProjectInfoSource{Name: "proj", Runtime: "go"},
+			wantInstallCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			lis, err := net.Listen("tcp", "localhost:0")
+			require.NoError(t, err)
+			mockSrv := &mockAutomationServer{pulumiVersion: "3.100.0"}
+			grpcSrv := grpc.NewServer()
+			agentpb.RegisterAutomationServiceServer(grpcSrv, mockSrv)
+			go func() { _ = grpcSrv.Serve(lis) }()
+			t.Cleanup(func() {
+				grpcSrv.Stop()
+				_ = lis.Close()
+			})
+			t.Setenv("WORKSPACE_LOCALHOST", lis.Addr().String())
+
+			workspaceName := fmt.Sprintf("ws-%s", utilrand.String(8))
+			workspace := &autov1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: workspaceName, Namespace: "default"},
+				Spec: autov1alpha1.WorkspaceSpec{
+					Image:       "pulumi/pulumi:latest-nonroot",
+					ProjectInfo: tt.projectInfo,
+				},
+			}
+			require.NoError(t, k8sclient.Create(ctx, workspace))
+			t.Cleanup(func() { _ = k8sclient.Delete(ctx, workspace) })
+
+			objName := types.NamespacedName{Name: workspaceName, Namespace: "default"}
+			r := &WorkspaceReconciler{
+				Client:            k8sclient,
+				Scheme:            k8sclient.Scheme(),
+				Recorder:          record.NewFakeRecorder(10),
+				ConnectionManager: &ConnectionManager{factory: &mockTokenSourceFactory{}},
+			}
+
+			// First reconciliation: creates the StatefulSet and Service.
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: objName})
+			require.NoError(t, err)
+
+			// Mark the StatefulSet ready and create a matching Pod so the next reconcile reaches
+			// the install step.
+			stsName := types.NamespacedName{Name: workspaceName + "-workspace", Namespace: "default"}
+			sts := &appsv1.StatefulSet{}
+			require.NoError(t, k8sclient.Get(ctx, stsName, sts))
+			sts.Status.ObservedGeneration = sts.Generation
+			sts.Status.Replicas = 1
+			sts.Status.ReadyReplicas = 1
+			sts.Status.AvailableReplicas = 1
+			sts.Status.CurrentRevision = testRevision
+			sts.Status.CurrentReplicas = 1
+			sts.Status.UpdateRevision = testRevision
+			sts.Status.UpdatedReplicas = 1
+			require.NoError(t, k8sclient.Status().Update(ctx, sts))
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-workspace-0", workspaceName),
+					Namespace: "default",
+					Labels:    map[string]string{"controller-revision-hash": testRevision},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "pulumi", Image: "pulumi/pulumi:latest-nonroot"}},
+				},
+			}
+			require.NoError(t, k8sclient.Create(ctx, pod))
+
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: objName})
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantInstallCalls, mockSrv.installCalls.Load(),
+				"unexpected number of Install RPCs")
+
+			require.NoError(t, k8sclient.Get(ctx, objName, workspace))
+			readyCond := meta.FindStatusCondition(workspace.Status.Conditions, autov1alpha1.WorkspaceReady)
+			require.NotNil(t, readyCond)
+			assert.Equal(t, metav1.ConditionTrue, readyCond.Status, "workspace should become ready")
+			assert.Nil(t, meta.FindStatusCondition(workspace.Status.Conditions, autov1alpha1.WorkspaceStalled))
+
 		})
 	}
 }


### PR DESCRIPTION
When we're running a project-info-bootstrapped workspace, the idea is to run `pulumi destroy` from project state only. If we try to run the Install step on the stack, this results in failures, since when there's no program in the Workspace, there's nothing to install.

Fixes https://github.com/pulumi/pulumi-kubernetes-operator/issues/1299.
