### PR TITLE
Fix Workspace initialization completion conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## Unreleased
 
+- Preserve Workspace Pods when recording initialization completion conflicts with unrelated metadata updates, and reject completion writes to same-name replacement Pods [#1330](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1330)
+
 ## 2.9.1 (2026-09-03)
 
 - Skip `pulumi install` for a project that runs a prebuilt binary (`runtime.options.binary`) [#1297](https://github.com/pulumi/pulumi-kubernetes-operator/issues/1297)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 ## Unreleased
 
-- Preserve Workspace Pods when recording initialization completion conflicts with unrelated metadata updates, and reject completion writes to same-name replacement Pods [#1330](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1330)
+- Preserve Workspace Pods on initialization-completion write failures, reject completion on replaced or terminating Pods, and avoid repeating environment imports during initialization retries [#1330](https://github.com/pulumi/pulumi-kubernetes-operator/pull/1330)
 
 ## 2.9.1 (2026-09-03)
 

--- a/agent/pkg/server/server.go
+++ b/agent/pkg/server/server.go
@@ -46,6 +46,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optrefresh"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/optup"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/esc/eval"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -544,6 +545,39 @@ func (s *Server) AddEnvironments(ctx context.Context, in *pb.AddEnvironmentsRequ
 	stack, err := s.ensureStack(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(in.Environment) != 0 {
+		settings, err := stack.Workspace().StackSettings(ctx, stack.Name())
+		if err != nil {
+			return nil, err
+		}
+		// Completion writes can fail after initialization. Recognize an already
+		// appended suffix without rewriting prior imports or inline values.
+		// Environment.Imports() includes a synthetic "yaml" entry for inline values.
+		if definition := settings.Environment.Definition(); len(definition) != 0 {
+			def, diags, err := eval.LoadYAMLBytes("yaml", definition)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse stack environment: %w", err)
+			}
+			if diags.HasErrors() {
+				return nil, fmt.Errorf("invalid stack environment: %w", diags)
+			}
+			imports := def.Imports.GetElements()
+			if len(imports) >= len(in.Environment) {
+				matches := true
+				for i, imp := range imports[len(imports)-len(in.Environment):] {
+					if imp.Environment.GetValue() != in.Environment[i] ||
+						(imp.Meta != nil && imp.Meta.Merge != nil && !imp.Meta.Merge.Value) {
+						matches = false
+						break
+					}
+				}
+				if matches {
+					return &pb.AddEnvironmentsResult{}, nil
+				}
+			}
+		}
 	}
 
 	err = stack.AddEnvironments(ctx, in.Environment...)

--- a/agent/pkg/server/server_test.go
+++ b/agent/pkg/server/server_test.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
+	"gopkg.in/yaml.v3"
 	"k8s.io/utils/ptr"
 
 	pb "github.com/pulumi/pulumi-kubernetes-operator/v2/agent/pkg/proto"
@@ -841,11 +842,13 @@ func TestSetEnvironments(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		stacks  []string
-		req     *pb.AddEnvironmentsRequest
-		wantErr error
-		want    []string
+		name        string
+		stacks      []string
+		req         *pb.AddEnvironmentsRequest
+		wantErr     error
+		environment string
+		wantNoop    bool
+		wantInvalid bool
 	}{
 		{
 			name:    "no active stack",
@@ -859,7 +862,57 @@ func TestSetEnvironments(t *testing.T) {
 			req: &pb.AddEnvironmentsRequest{
 				Environment: []string{"test"},
 			},
-			want: []string{"test"},
+		},
+		{
+			name:        "retry preserves prior imports",
+			stacks:      []string{TestStackName},
+			req:         &pb.AddEnvironmentsRequest{Environment: []string{"a", "b"}},
+			environment: `["prior", "a", "b"]`,
+			wantNoop:    true,
+		},
+		{
+			name:        "retry preserves inline values and equivalent merge metadata",
+			stacks:      []string{TestStackName},
+			req:         &pb.AddEnvironmentsRequest{Environment: []string{"a", "b"}},
+			environment: `{"imports":["prior", {"a":{}}, {"b":{"merge":true}}], "values":{"retained":{"nested":"value"}}}`,
+			wantNoop:    true,
+		},
+		{
+			name:        "different order still appends",
+			stacks:      []string{TestStackName},
+			req:         &pb.AddEnvironmentsRequest{Environment: []string{"a", "b"}},
+			environment: `["b", "a"]`,
+		},
+		{
+			name:        "earlier occurrence still appends",
+			stacks:      []string{TestStackName},
+			req:         &pb.AddEnvironmentsRequest{Environment: []string{"a", "b"}},
+			environment: `["a", "b", "later"]`,
+		},
+		{
+			name:        "partial suffix still appends",
+			stacks:      []string{TestStackName},
+			req:         &pb.AddEnvironmentsRequest{Environment: []string{"a", "b"}},
+			environment: `["b"]`,
+		},
+		{
+			name:        "nonmerging import still appends",
+			stacks:      []string{TestStackName},
+			req:         &pb.AddEnvironmentsRequest{Environment: []string{"a", "b"}},
+			environment: `{"imports":[{"a":{"merge":false}}, "b"]}`,
+		},
+		{
+			name:        "invalid merge metadata fails before append",
+			stacks:      []string{TestStackName},
+			req:         &pb.AddEnvironmentsRequest{Environment: []string{"a"}},
+			environment: `{"imports":[{"a":{"merge":"invalid"}}]}`,
+			wantInvalid: true,
+		},
+		{
+			name:        "inline values are not an import named yaml",
+			stacks:      []string{TestStackName},
+			req:         &pb.AddEnvironmentsRequest{Environment: []string{"yaml"}},
+			environment: `{"imports":["prior"], "values":{"retained":"value"}}`,
 		},
 	}
 	for _, tt := range tests {
@@ -867,17 +920,35 @@ func TestSetEnvironments(t *testing.T) {
 			t.Parallel()
 			ctx := newContext(t)
 			tc := newTC(ctx, t, tcOptions{ProjectDir: "./testdata/simple", Stacks: tt.stacks})
+			if tt.environment != "" {
+				settings, err := tc.ws.StackSettings(ctx, tc.stack.Name())
+				require.NoError(t, err)
+				require.NoError(t, yaml.Unmarshal([]byte(tt.environment), &settings.Environment))
+				require.NoError(t, tc.ws.SaveStackSettings(ctx, tc.stack.Name(), settings))
+			}
 			_, err := tc.server.AddEnvironments(ctx, tt.req)
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)
 				return
 			}
 
-			// note: the file backend does not support environments
-			assert.ErrorContains(t, err, "does not support environments")
-			// actual, err := tc.ws.ListEnvironments(ctx, tc.stack.Name())
-			// assert.NoError(t, err)
-			// assert.Equal(t, tt.want, actual)
+			if tt.wantInvalid {
+				assert.ErrorContains(t, err, "invalid stack environment")
+			} else if tt.wantNoop {
+				require.NoError(t, err)
+				// A second retry must also leave the persisted definition intact.
+				_, err = tc.server.AddEnvironments(ctx, tt.req)
+				require.NoError(t, err)
+				settings, err := tc.ws.StackSettings(ctx, tc.stack.Name())
+				require.NoError(t, err)
+				var expected workspace.Environment
+				require.NoError(t, yaml.Unmarshal([]byte(tt.environment), &expected))
+				assert.YAMLEq(t, string(expected.Definition()), string(settings.Environment.Definition()))
+			} else {
+				// The file backend rejects ESC additions. This proves unmatched
+				// requests still reach the existing CLI validation instead of succeeding.
+				assert.ErrorContains(t, err, "does not support environments")
+			}
 		})
 	}
 }

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -269,6 +269,7 @@ func main() {
 
 	if err = (&autocontroller.WorkspaceReconciler{
 		Client:            mgr.GetClient(),
+		APIReader:         mgr.GetAPIReader(),
 		Scheme:            mgr.GetScheme(),
 		Recorder:          mgr.GetEventRecorderFor("workspace-controller"),
 		ConnectionManager: cm,

--- a/operator/internal/controller/auto/workspace_controller.go
+++ b/operator/internal/controller/auto/workspace_controller.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto/md5" //nolint:gosec
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -44,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	metav1apply "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	hashutil "k8s.io/kubernetes/pkg/util/hash"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -75,6 +75,7 @@ const (
 // WorkspaceReconciler reconciles a Workspace object
 type WorkspaceReconciler struct {
 	client.Client
+	APIReader         client.Reader
 	Scheme            *runtime.Scheme
 	Recorder          record.EventRecorder
 	ConnectionManager *ConnectionManager
@@ -414,18 +415,26 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 		}
 
-		// Initialization can outlive unrelated Pod updates. Patch only its completion
-		// marker, retaining the UID so a same-name replacement cannot be marked initialized.
-		patch, err := json.Marshal(map[string]any{
-			"metadata": map[string]any{
-				"uid":         pod.UID,
-				"annotations": map[string]string{PodAnnotationInitialized: "true"},
-			},
+		// Initialization can outlive Pod updates or deletion. Retry only the completion
+		// write, using resourceVersion to keep the UID and deletion checks atomic.
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			current := &corev1.Pod{}
+			if err := r.APIReader.Get(ctx, client.ObjectKeyFromObject(pod), current); err != nil {
+				return err
+			}
+			if current.UID != pod.UID {
+				return fmt.Errorf("workspace pod was replaced during initialization")
+			}
+			if current.DeletionTimestamp != nil {
+				return fmt.Errorf("workspace pod is terminating")
+			}
+			patch := client.MergeFromWithOptions(current.DeepCopy(), client.MergeFromWithOptimisticLock{})
+			if current.Annotations == nil {
+				current.Annotations = make(map[string]string)
+			}
+			current.Annotations[PodAnnotationInitialized] = "true"
+			return r.Patch(ctx, current, patch, client.FieldOwner(FieldManager))
 		})
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		err = r.Patch(ctx, pod, client.RawPatch(types.MergePatchType, patch), client.FieldOwner(FieldManager))
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to mark the workspace pod initialized: %w", err)
 		}

--- a/operator/internal/controller/auto/workspace_controller.go
+++ b/operator/internal/controller/auto/workspace_controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/md5" //nolint:gosec
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -413,19 +414,20 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			}
 		}
 
-		// set the "initialized" annotation
-		if pod.Annotations == nil {
-			pod.Annotations = make(map[string]string)
-		}
-		pod.Annotations[PodAnnotationInitialized] = "true"
-		err = r.Update(ctx, pod, client.FieldOwner(FieldManager))
+		// Initialization can outlive unrelated Pod updates. Patch only its completion
+		// marker, retaining the UID so a same-name replacement cannot be marked initialized.
+		patch, err := json.Marshal(map[string]any{
+			"metadata": map[string]any{
+				"uid":         pod.UID,
+				"annotations": map[string]string{PodAnnotationInitialized: "true"},
+			},
+		})
 		if err != nil {
-			l.Error(err, "unable to update the workspace pod; deleting the pod to retry later")
-			err = r.Delete(ctx, pod)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-			return ctrl.Result{}, fmt.Errorf("failed to update the pod: %w", err)
+			return ctrl.Result{}, err
+		}
+		err = r.Patch(ctx, pod, client.RawPatch(types.MergePatchType, patch), client.FieldOwner(FieldManager))
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to mark the workspace pod initialized: %w", err)
 		}
 		l.Info("workspace pod initialized")
 		emitEvent(r.Recorder, w, autov1alpha1.InitializedEvent(), "Initialized workspace pod %q", pod.Name)

--- a/operator/internal/controller/auto/workspace_controller_test.go
+++ b/operator/internal/controller/auto/workspace_controller_test.go
@@ -107,9 +107,10 @@ var _ = Describe("Workspace Controller", func() {
 			_ = k8sClient.Delete(ctx, obj)
 		})
 		r = &WorkspaceReconciler{
-			Client:   k8sClient,
-			Scheme:   k8sClient.Scheme(),
-			Recorder: record.NewFakeRecorder(10),
+			Client:    k8sClient,
+			APIReader: k8sClient,
+			Scheme:    k8sClient.Scheme(),
+			Recorder:  record.NewFakeRecorder(10),
 		}
 	})
 
@@ -745,9 +746,10 @@ func TestWorkspaceInitializationStalled(t *testing.T) {
 
 			objName := types.NamespacedName{Name: workspaceName, Namespace: "default"}
 			r := &WorkspaceReconciler{
-				Client:   k8sclient,
-				Scheme:   k8sclient.Scheme(),
-				Recorder: record.NewFakeRecorder(10),
+				Client:    k8sclient,
+				APIReader: k8sclient,
+				Scheme:    k8sclient.Scheme(),
+				Recorder:  record.NewFakeRecorder(10),
 				ConnectionManager: &ConnectionManager{
 					factory: &mockTokenSourceFactory{},
 				},
@@ -830,7 +832,7 @@ func TestWorkspaceInitializationCompletion(t *testing.T) {
 	k8sclient, err := client.NewWithWatch(cfg, client.Options{Scheme: scheme.Scheme})
 	require.NoError(t, err)
 
-	for _, scenario := range []string{"metadata update", "replacement", "deleted", "write failure"} {
+	for _, scenario := range []string{"metadata update", "replacement", "deleted", "terminating", "write failure"} {
 		t.Run(scenario, func(t *testing.T) {
 			ctx := t.Context()
 			workspace := &autov1alpha1.Workspace{
@@ -841,6 +843,7 @@ func TestWorkspaceInitializationCompletion(t *testing.T) {
 			objName := client.ObjectKeyFromObject(workspace)
 			r := &WorkspaceReconciler{
 				Client:            k8sclient,
+				APIReader:         k8sclient,
 				Scheme:            k8sclient.Scheme(),
 				Recorder:          record.NewFakeRecorder(20),
 				ConnectionManager: &ConnectionManager{factory: &mockTokenSourceFactory{}},
@@ -868,6 +871,9 @@ func TestWorkspaceInitializationCompletion(t *testing.T) {
 					Labels: map[string]string{"controller-revision-hash": testRevision},
 				},
 				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "pulumi", Image: workspace.Spec.Image}}},
+			}
+			if scenario == "terminating" {
+				pod.Finalizers = []string{TestFinalizer}
 			}
 			require.NoError(t, k8sclient.Create(ctx, pod))
 			podKey := client.ObjectKeyFromObject(pod)
@@ -908,11 +914,33 @@ func TestWorkspaceInitializationCompletion(t *testing.T) {
 			t.Cleanup(func() { grpcSrv.Stop(); _ = lis.Close() })
 			t.Setenv("WORKSPACE_LOCALHOST", lis.Addr().String())
 
-			if scenario == "write failure" {
+			if scenario == "metadata update" || scenario == "write failure" || scenario == "terminating" {
+				conflictInjected := false
 				r.Client = interceptor.NewClient(k8sclient, interceptor.Funcs{
 					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 						if _, ok := obj.(*corev1.Pod); ok {
-							return apierrors.NewServiceUnavailable("temporary Pod write failure")
+							if scenario == "write failure" {
+								return apierrors.NewServiceUnavailable("temporary Pod write failure")
+							}
+							if scenario == "terminating" && !conflictInjected {
+								// Begin deletion after the completion read, before its write.
+								if err := c.Delete(ctx, pod, client.GracePeriodSeconds(0)); err != nil {
+									return err
+								}
+								conflictInjected = true
+							}
+							if !conflictInjected {
+								// Change metadata after the completion read, forcing a real API conflict.
+								fresh := &corev1.Pod{}
+								if err := c.Get(ctx, podKey, fresh); err != nil {
+									return err
+								}
+								fresh.Labels["other.example.com/concurrent"] = "true"
+								if err := c.Update(ctx, fresh); err != nil {
+									return err
+								}
+								conflictInjected = true
+							}
 						}
 						return c.Patch(ctx, obj, patch, opts...)
 					},
@@ -940,6 +968,12 @@ func TestWorkspaceInitializationCompletion(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+			if scenario == "terminating" {
+				assert.Equal(t, originalUID, current.UID)
+				assert.NotNil(t, current.DeletionTimestamp)
+				assert.Empty(t, current.Annotations[PodAnnotationInitialized])
+				return
+			}
 			assert.Nil(t, current.DeletionTimestamp)
 			if scenario == "replacement" {
 				assert.NotEqual(t, originalUID, current.UID)
@@ -950,6 +984,8 @@ func TestWorkspaceInitializationCompletion(t *testing.T) {
 			if scenario == "metadata update" {
 				assert.Equal(t, "true", current.Annotations[PodAnnotationInitialized])
 				assert.Equal(t, "true", current.Annotations["other.example.com/observed"])
+				assert.Equal(t, "true", current.Labels["other.example.com/concurrent"])
+				assert.Equal(t, int32(1), mockSrv.installCalls.Load(), "a completion conflict must not repeat initialization")
 			} else {
 				assert.Empty(t, current.Annotations[PodAnnotationInitialized])
 				// The next reconciliation recovers once the API is writable again.
@@ -1029,6 +1065,7 @@ func TestWorkspaceSkipInstall(t *testing.T) {
 			objName := types.NamespacedName{Name: workspaceName, Namespace: "default"}
 			r := &WorkspaceReconciler{
 				Client:            k8sclient,
+				APIReader:         k8sclient,
 				Scheme:            k8sclient.Scheme(),
 				Recorder:          record.NewFakeRecorder(10),
 				ConnectionManager: &ConnectionManager{factory: &mockTokenSourceFactory{}},
@@ -1117,9 +1154,10 @@ func TestWorkspaceStatusConcurrentModification(t *testing.T) {
 
 	objName := types.NamespacedName{Name: workspace.Name, Namespace: workspace.Namespace}
 	reconciler := &WorkspaceReconciler{
-		Client:   k8sclient,
-		Scheme:   k8sclient.Scheme(),
-		Recorder: record.NewFakeRecorder(10),
+		Client:    k8sclient,
+		APIReader: k8sclient,
+		Scheme:    k8sclient.Scheme(),
+		Recorder:  record.NewFakeRecorder(10),
 		ConnectionManager: &ConnectionManager{
 			factory: &mockTokenSourceFactory{},
 		},

--- a/operator/internal/controller/auto/workspace_controller_test.go
+++ b/operator/internal/controller/auto/workspace_controller_test.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,6 +44,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -628,14 +630,20 @@ type mockAutomationServer struct {
 	selectStackErr error
 	installErr     error
 	installCalls   atomic.Int32
+	onInstall      func(context.Context) error
 }
 
 func (s *mockAutomationServer) PulumiVersion(_ context.Context, _ *agentpb.PulumiVersionRequest) (*agentpb.PulumiVersionResult, error) {
 	return &agentpb.PulumiVersionResult{Version: s.pulumiVersion}, nil
 }
 
-func (s *mockAutomationServer) Install(_ context.Context, _ *agentpb.InstallRequest) (*agentpb.InstallResult, error) {
+func (s *mockAutomationServer) Install(ctx context.Context, _ *agentpb.InstallRequest) (*agentpb.InstallResult, error) {
 	s.installCalls.Add(1)
+	if s.onInstall != nil {
+		if err := s.onInstall(ctx); err != nil {
+			return nil, err
+		}
+	}
 	if s.installErr != nil {
 		return nil, s.installErr
 	}
@@ -804,6 +812,156 @@ func TestWorkspaceInitializationStalled(t *testing.T) {
 			podCheck := &corev1.Pod{}
 			require.NoError(t, k8sclient.Get(ctx, types.NamespacedName{Name: podName, Namespace: "default"}, podCheck))
 			assert.Nil(t, podCheck.DeletionTimestamp, "pod should not be marked for deletion")
+		})
+	}
+}
+
+// Exercise the completion write against the real API: initialization RPCs can
+// overlap metadata updates, Pod replacement, or temporary API write failures.
+func TestWorkspaceInitializationCompletion(t *testing.T) {
+	require.NoError(t, autov1alpha1.AddToScheme(scheme.Scheme))
+	env := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := env.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, env.Stop()) })
+	k8sclient, err := client.NewWithWatch(cfg, client.Options{Scheme: scheme.Scheme})
+	require.NoError(t, err)
+
+	for _, scenario := range []string{"metadata update", "replacement", "deleted", "write failure"} {
+		t.Run(scenario, func(t *testing.T) {
+			ctx := t.Context()
+			workspace := &autov1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "completion-" + utilrand.String(8), Namespace: "default"},
+				Spec:       autov1alpha1.WorkspaceSpec{Image: "pulumi/pulumi:latest-nonroot"},
+			}
+			require.NoError(t, k8sclient.Create(ctx, workspace))
+			objName := client.ObjectKeyFromObject(workspace)
+			r := &WorkspaceReconciler{
+				Client:            k8sclient,
+				Scheme:            k8sclient.Scheme(),
+				Recorder:          record.NewFakeRecorder(20),
+				ConnectionManager: &ConnectionManager{factory: &mockTokenSourceFactory{}},
+			}
+			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: objName})
+			require.NoError(t, err)
+
+			// envtest has no StatefulSet controller; supply its ready status and Pod.
+			sts := &appsv1.StatefulSet{}
+			require.NoError(t, k8sclient.Get(ctx, types.NamespacedName{
+				Name: workspace.Name + "-workspace", Namespace: workspace.Namespace,
+			}, sts))
+			sts.Status.ObservedGeneration = sts.Generation
+			sts.Status.Replicas = 1
+			sts.Status.ReadyReplicas = 1
+			sts.Status.AvailableReplicas = 1
+			sts.Status.CurrentReplicas = 1
+			sts.Status.UpdatedReplicas = 1
+			sts.Status.CurrentRevision = testRevision
+			sts.Status.UpdateRevision = testRevision
+			require.NoError(t, k8sclient.Status().Update(ctx, sts))
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: workspace.Name + "-workspace-0", Namespace: workspace.Namespace,
+					Labels: map[string]string{"controller-revision-hash": testRevision},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "pulumi", Image: workspace.Spec.Image}}},
+			}
+			require.NoError(t, k8sclient.Create(ctx, pod))
+			podKey := client.ObjectKeyFromObject(pod)
+			originalUID := pod.UID
+			mockSrv := &mockAutomationServer{
+				pulumiVersion: "3.100.0",
+				onInstall: func(ctx context.Context) error {
+					switch scenario {
+					case "metadata update":
+						fresh := &corev1.Pod{}
+						if err := k8sclient.Get(ctx, podKey, fresh); err != nil {
+							return err
+						}
+						fresh.Annotations = map[string]string{"other.example.com/observed": "true"}
+						return k8sclient.Update(ctx, fresh)
+					case "replacement", "deleted":
+						if err := k8sclient.Delete(ctx, pod, client.GracePeriodSeconds(0)); err != nil {
+							return err
+						}
+						if scenario == "replacement" {
+							replacement := &corev1.Pod{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: pod.Name, Namespace: pod.Namespace, Labels: pod.Labels,
+								},
+								Spec: pod.Spec,
+							}
+							return k8sclient.Create(ctx, replacement)
+						}
+					}
+					return nil
+				},
+			}
+			lis, err := net.Listen("tcp", "localhost:0")
+			require.NoError(t, err)
+			grpcSrv := grpc.NewServer()
+			agentpb.RegisterAutomationServiceServer(grpcSrv, mockSrv)
+			go func() { _ = grpcSrv.Serve(lis) }()
+			t.Cleanup(func() { grpcSrv.Stop(); _ = lis.Close() })
+			t.Setenv("WORKSPACE_LOCALHOST", lis.Addr().String())
+
+			if scenario == "write failure" {
+				r.Client = interceptor.NewClient(k8sclient, interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if _, ok := obj.(*corev1.Pod); ok {
+							return apierrors.NewServiceUnavailable("temporary Pod write failure")
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				})
+			}
+
+			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: objName})
+			if scenario == "metadata update" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+			require.NoError(t, k8sclient.Get(ctx, objName, workspace))
+			ready := meta.FindStatusCondition(workspace.Status.Conditions, autov1alpha1.WorkspaceReady)
+			require.NotNil(t, ready)
+			if scenario == "metadata update" {
+				assert.Equal(t, metav1.ConditionTrue, ready.Status)
+			} else {
+				assert.Equal(t, metav1.ConditionFalse, ready.Status)
+			}
+			current := &corev1.Pod{}
+			err = k8sclient.Get(ctx, podKey, current)
+			if scenario == "deleted" {
+				assert.True(t, apierrors.IsNotFound(err), "completion must not recreate a deleted Pod")
+				return
+			}
+			require.NoError(t, err)
+			assert.Nil(t, current.DeletionTimestamp)
+			if scenario == "replacement" {
+				assert.NotEqual(t, originalUID, current.UID)
+				assert.Empty(t, current.Annotations[PodAnnotationInitialized])
+				return
+			}
+			assert.Equal(t, originalUID, current.UID)
+			if scenario == "metadata update" {
+				assert.Equal(t, "true", current.Annotations[PodAnnotationInitialized])
+				assert.Equal(t, "true", current.Annotations["other.example.com/observed"])
+			} else {
+				assert.Empty(t, current.Annotations[PodAnnotationInitialized])
+				// The next reconciliation recovers once the API is writable again.
+				r.Client = k8sclient
+				_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: objName})
+				require.NoError(t, err)
+				require.NoError(t, k8sclient.Get(ctx, podKey, current))
+				assert.Equal(t, originalUID, current.UID)
+				assert.Equal(t, "true", current.Annotations[PodAnnotationInitialized])
+				require.NoError(t, k8sclient.Get(ctx, objName, workspace))
+				assert.True(t, meta.IsStatusConditionTrue(workspace.Status.Conditions, autov1alpha1.WorkspaceReady))
+			}
 		})
 	}
 }


### PR DESCRIPTION
### Proposed changes

Workspace initialization reads a Pod before making RPC calls, then marks it initialized. An unrelated metadata update during those calls makes the saved resourceVersion stale. The full Pod Update fails, and the controller deletes the Pod to retry. Repeated conflicts can prevent the Workspace from becoming Ready.

Read the Pod directly from the API after initialization, check its UID and deletion timestamp, then patch the initialized annotation with a resourceVersion precondition. Use client-go RetryOnConflict to retry only this metadata operation. This preserves unrelated metadata and rejects a Pod replacement or deletion that starts between the check and write. On a write error, retain the Pod and return the error so controller-runtime can retry.

Because a later reconciliation can repeat initialization on the same Pod, AddEnvironments now treats an identical ordered import suffix as a no-op. It uses the installed Pulumi SDK's environment parser and preserves prior imports, merge options, and inline values. Unmatched requests still use the existing SDK append operation. Normal source/configuration rollouts still use the existing StatefulSet path.

### Verification

- Added an envtest regression using the real Kubernetes API and the existing mock initialization RPC server. It covers concurrent metadata updates, same-name replacement, deletion, deletion starting between the completion read and write, and recovery after a temporary write failure. An actual API conflict retries the metadata operation without repeating the Install RPC.
- The new test passes on this change. Against unmodified master, the concurrent-update case fails and the replacement case shows that the newly created Pod is deleted.
- `go test -short ./operator/...`: passed with Kubernetes envtest 1.32.0 and Go 1.26.6.
- `go test ./agent/...`: passed with Go 1.26.6 and Pulumi CLI 3.256.0.
- `make -C operator lint`: passed, 0 issues.
- `make -C agent lint`: passed, 0 issues.
- Focused agent environment and stack-selection tests passed with Pulumi CLI 3.256.0. Repeated environment initialization preserves existing ordered imports and inline values; unmatched requests still reach CLI validation. The file backend cannot verify a successful first-time ESC import, so those cases verify its existing rejection instead.
- `go test -race ./operator/internal/controller/auto -run '^TestWorkspaceInitializationCompletion$' -count=1`: passed.
- `git diff --check`: passed.

The regression needs envtest because fake clients do not establish API resourceVersion and UID validation behavior. It checks retained object identity, preserved metadata, and Ready status, without adding production test hooks.

### Review focus

The completion write must use the resourceVersion from the uncached UID/deletion check. Completion-write failures must not delete the Pod or report Ready. Repeated environment initialization must not add duplicate imports or confuse inline values with an import named yaml.
